### PR TITLE
[COOK-1317] RabbitMQ cookbook is installing a very old / incorrect version of RabbitMQ

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default[:rabbitmq][:default_pass] = 'guest'
 default[:rabbitmq][:cluster] = false
 default[:rabbitmq][:cluster_disk_nodes] = []
 default[:rabbitmq][:erlang_cookie] = 'AnyAlphaNumericStringWillDo'
+default[:rabbitmq][:erlang_cookie_path] = '/var/lib/rabbitmq/.erlang.cookie'
 
 #ssl
 default[:rabbitmq][:ssl] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,8 +62,8 @@ when "redhat", "centos", "scientific", "amazon"
   end
 end
 
-if File.exists?('/var/lib/rabbitmq/.erlang.cookie')
-  existing_erlang_key =  File.read('/var/lib/rabbitmq/.erlang.cookie')
+if File.exists?(node[:rabbitmq][:erlang_cookie_path])
+  existing_erlang_key =  File.read(node[:rabbitmq][:erlang_cookie_path])
 else
   existing_erlang_key = ""
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1317

I discovered three bugs during the process to get this cookbook to install the proper version and function as a part of a cluster.
- The apt repo was not firing off apt-get update so the very old Canonical rabbitmq-server package was being installed.
- The new package contains an init script that does not sit well with being fired off from chef. It turned out to be a problem with unix process groups and I had to force the RabbitMQ init script to fork properly with the setsid command. More info in the comments in the code and the jira ticket.
- Setting a specific erlang cookie with the attributes doesn't work out of the box. The deb package generates a random erlang key and the template never overwrites it because it has a not_if File.exists? statement blocking it. I fixed it so that the erlang key will always be configurable by the attributes.

This was tested on EC2 with the Ubuntu 10.04 image.
