### PR TITLE
[COOK-1319] RabbitMQ cookbook should be able to pass in the data and log directories via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,10 @@ default[:rabbitmq][:cluster] = false
 default[:rabbitmq][:cluster_disk_nodes] = []
 default[:rabbitmq][:erlang_cookie] = 'AnyAlphaNumericStringWillDo'
 
+# directories
+default[:rabbitmq][:data_directory] = '/var/lib/rabbitmq'
+default[:rabbitmq][:log_directory] = '/var/log/rabbitmq'
+
 #ssl
 default[:rabbitmq][:ssl] = false
 default[:rabbitmq][:ssl_port] = '5671'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,6 +59,68 @@ when "redhat", "centos", "scientific"
   end
 end
 
+unless File.exists?('/var/lib/rabbitmq/.custom_directories_set')
+  
+  execute "rabbitmq-stop" do
+    command "setsid /etc/init.d/rabbitmq-server stop"
+    action :run
+  end
+  
+  if node[:rabbitmq][:data_directory] != '/var/lib/rabbitmq'
+    directory node[:rabbitmq][:data_directory] do
+      mode "0775"
+      owner "rabbitmq"
+      group "rabbitmq"
+      action :create
+      recursive true
+    end
+    
+    bash "move-data-dir" do
+      user "root"
+      code <<-EOH
+      mv /var/lib/rabbitmq #{node[:rabbitmq][:data_directory]}
+      EOH
+    end
+  
+    link "/var/lib/rabbitmq" do
+      to node[:rabbitmq][:data_directory]
+    end 
+  end
+  
+  if node[:rabbitmq][:log_directory] != '/var/log/rabbitmq'
+    directory node[:rabbitmq][:log_directory] do
+      mode "0775"
+      owner "rabbitmq"
+      group "rabbitmq"
+      action :create
+      recursive true
+    end
+    
+    bash "move-log-dir" do
+      user "root"
+      code <<-EOH
+      mv /var/log/rabbitmq #{node[:rabbitmq][:log_directory]}
+      EOH
+    end
+  
+    link "/var/log/rabbitmq" do
+      to node[:rabbitmq][:log_directory]
+    end
+  end
+  
+  execute "rabbitmq-start" do
+    command "setsid /etc/init.d/rabbitmq-server start"
+    action :run
+  end
+  
+  bash "make-directory-changes-one-time-idempotent" do
+    user "root"
+    code <<-EOH
+    touch /var/lib/rabbitmq/.custom_directories_set
+    EOH
+  end
+end
+
 if File.exists?('/var/lib/rabbitmq/.erlang.cookie')
   @existing_erlang_key =  File.read('/var/lib/rabbitmq/.erlang.cookie')
 else
@@ -70,7 +132,7 @@ if node[:rabbitmq][:cluster] and node[:rabbitmq][:erlang_cookie] != @existing_er
       command "setsid /etc/init.d/rabbitmq-server stop"
       action :run
     end
-
+    
     template "/var/lib/rabbitmq/.erlang.cookie" do
       source "doterlang.cookie.erb"
       owner "rabbitmq"


### PR DESCRIPTION
This is based off work done in COOK-1317. If I need to resubmit this in a different way so it doesn't contain the commits from that ticket as well just let me know.

This pull request fixes two things:
- For the initial setup you can now configure the data directory and the log directory.

I assume that the "one time run" dotfile is the best way to make a set of resources run just once but if there's a better way I can fix it.

http://tickets.opscode.com/browse/COOK-1319
