### PR TITLE
Plugin configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,9 @@ default[:rabbitmq][:config] = nil
 default[:rabbitmq][:logdir] = nil
 default[:rabbitmq][:mnesiadir] = nil
 
+# Plugins; by default, no plugins are enabled
+default[:rabbitmq][:enabled_plugins] = []
+
 # RabbitMQ version to install for "redhat", "centos", "scientific", and "amazon". We default to 
 # 2.6.1, because that was what was installed in the previous version of the cookbook.
 default[:rabbitmq][:version] = '2.6.1'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -80,6 +80,14 @@ template "/etc/rabbitmq/rabbitmq.config" do
   notifies :restart, "service[rabbitmq-server]", :immediately
 end
 
+template "/etc/rabbitmq/enabled_plugins" do
+  source "enabled_plugins.erb"
+  owner "root"
+  group "root"
+  mode 0644
+  notifies :restart, "service[rabbitmq-server]", :immediately
+end
+
 service "rabbitmq-server" do
   stop_command "/usr/sbin/rabbitmqctl stop"
   supports :status => true, :restart => true

--- a/templates/default/enabled_plugins.erb
+++ b/templates/default/enabled_plugins.erb
@@ -1,0 +1,1 @@
+[<%= node[:rabbitmq][:enabled_plugins].map{|n| "#{n}"}.join(',') %>].


### PR DESCRIPTION
The [:rabbitmq][:enabled_plugins] node allows you to specify which plugins will be enabled in the RMQ installation.
