### PR TITLE
Fixing issue with existing config file for Ubuntu 12.04, as per COOK-1416.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,14 +28,6 @@ directory "/etc/rabbitmq/" do
   action :create
 end
 
-template "/etc/rabbitmq/rabbitmq-env.conf" do
-  source "rabbitmq-env.conf.erb"
-  owner "root"
-  group "root"
-  mode 0644
-  notifies :restart, "service[rabbitmq-server]"
-end
-
 case node['platform']
 when "debian", "ubuntu"
   # use the RabbitMQ repository instead of Ubuntu or Debian's
@@ -64,6 +56,14 @@ when "redhat", "centos", "scientific", "amazon", "fedora"
     action :install
   end
 
+end
+
+template "/etc/rabbitmq/rabbitmq-env.conf" do
+  source "rabbitmq-env.conf.erb"
+  owner "root"
+  group "root"
+  mode 0644
+  notifies :restart, "service[rabbitmq-server]"
 end
 
 ## You'll see setsid used in all the init statements in this cookbook. This


### PR DESCRIPTION
If /etc/rabbitmq/rabbitmq-env.conf, package installation fails on Ubuntu 12.04. Moved template block after package install, but don't have CentOS to test. See COOK-1416.
