### PR TITLE
fixed unbalanced quote

### DIFF
--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -8,7 +8,7 @@
     {cluster_nodes, [<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>]},
 <% end %>
 <% if node['rabbitmq']['ssl'] -%>
-    {ssl_listeners, [<%= node['rabbitmq']['ssl_port'] %>']},
+    {ssl_listeners, '[<%= node['rabbitmq']['ssl_port'] %>']},
     {ssl_options, [{cacertfile,"<%= node['rabbitmq']['ssl_cacert'] %>"},
                     {certfile,"<%= node['rabbitmq']['ssl_cert'] %>"},
                     {keyfile,"<%= node['rabbitmq']['ssl_key'] %>"},


### PR DESCRIPTION
If the quote is not closed, rabbitmq is not starting, searching for a trailing "." in the config file.
