### PR TITLE
[COOK-1613] plugin provider fixes

### DIFF
--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -18,7 +18,7 @@
 #
 
 action :enable do
-  unless system("rabbitmq-plugins list #{new_resource.plugin} | grep '\\[[Ee]\\] #{new_resource.plugin}'")
+  unless system("rabbitmq-plugins list -e -m #{new_resource.plugin} | grep -qx '#{new_resource.plugin}'")
     execute "rabbitmq-plugins enable #{new_resource.plugin}" do
       Chef::Log.info "Enabling RabbitMQ plugin '#{new_resource.plugin}'."
       new_resource.updated_by_last_action(true)
@@ -27,7 +27,7 @@ action :enable do
 end
 
 action :disable do
-  if system("rabbitmq-plugins list #{new_resource.plugin} | grep '\\[[Ee]\\] #{new_resource.plugin}'")
+  if system("rabbitmq-plugins list -e -m #{new_resource.plugin} | grep -qx '#{new_resource.plugin}'")
     execute "rabbitmq-plugins disable #{new_resource.plugin}" do
       Chef::Log.info "Disabling RabbitMQ plugin '#{new_resource.plugin}'."
       new_resource.updated_by_last_action(true)


### PR DESCRIPTION
Fix for COOK-1613: 
-e parameter enables show only of implicit and explicit enabled plugins (analog to original [[Ee]] match)
-m simple plugin display - just plugin name on line alone

'grep' is used with -x switch - full line match - thus whole plugin name should match.
