### PR TITLE
properly support rpm version-release specification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+metadata.json

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,7 +7,7 @@ default['rabbitmq']['logdir'] = nil
 default['rabbitmq']['mnesiadir'] = nil
 
 # RabbitMQ version to install for "redhat", "centos", "scientific", and "amazon".
-default['rabbitmq']['version'] = '2.8.4'
+default['rabbitmq']['version'] = '2.6.1'
 default['rabbitmq']['arch'] = 'noarch'
 default['rabbitmq']['release'] = '1'
 # Override this if you have a yum repo with rabbitmq available.

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -18,20 +18,17 @@
 #
 
 action :enable do
-  unless system("rabbitmq-plugins list #{new_resource.plugin} | grep '\\[[Ee]\\] #{new_resource.plugin}'")
-    execute "rabbitmq-plugins enable #{new_resource.plugin}" do
-      Chef::Log.info "Enabling RabbitMQ plugin '#{new_resource.plugin}'."
-      new_resource.updated_by_last_action(true)
-    end
+  execute "rabbitmq-plugins enable #{new_resource.plugin}" do
+    Chef::Log.info "Enabling RabbitMQ plugin '#{new_resource.plugin}'."
+    new_resource.updated_by_last_action(true)
+    only_unless system("rabbitmq-plugins list #{new_resource.plugin} | grep '\\[[Ee]\\] #{new_resource.plugin}'")
   end
 end
 
 action :disable do
-  if system("rabbitmq-plugins list #{new_resource.plugin} | grep '\\[[Ee]\\] #{new_resource.plugin}'")
-    execute "rabbitmq-plugins disable #{new_resource.plugin}" do
-      Chef::Log.info "Disabling RabbitMQ plugin '#{new_resource.plugin}'."
-      new_resource.updated_by_last_action(true)
-    end
+  execute "rabbitmq-plugins disable #{new_resource.plugin}" do
+    Chef::Log.info "Disabling RabbitMQ plugin '#{new_resource.plugin}'."
+    new_resource.updated_by_last_action(true)
+    only_if system("rabbitmq-plugins list #{new_resource.plugin} | grep '\\[[Ee]\\] #{new_resource.plugin}'")
   end
 end
-

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,12 +40,9 @@ case node['platform']
 when "debian", "ubuntu"
   # use the RabbitMQ repository instead of Ubuntu or Debian's
   # because there are very useful features in the newer versions
-  apt_repository "rabbitmq" do
-    uri "http://www.rabbitmq.com/debian/"
-    distribution "testing"
-    components ["main"]
-    key "http://www.rabbitmq.com/rabbitmq-signing-key-public.asc"
-    action :add
+  package "rabbitmq-server" do
+    action :upgrade
+    options "-o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef'"
   end
 
   # installs the required setsid command -- should be there by default but just in case
@@ -56,8 +53,8 @@ when "redhat", "centos", "scientific", "amazon", "fedora"
 
   if node['rabbitmq']['use_yum'] then
     yum_package "rabbitmq-server" do
-      version "#{node['rabbitmq']['version']}"-"#{node['rabbitmq']['release']}"
-      arch "#{node['rabbitmq']['arch']}"
+      version "#{node['rabbitmq']['version']}-#{node['rabbitmq']['release']}"
+      arch node['rabbitmq']['arch']
       action :install
     end
   else

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -18,5 +18,6 @@
 #
 
 actions :enable, :disable
+default_action :enable
 
 attribute :plugin, :kind_of => String, :name_attribute => true


### PR DESCRIPTION
- add ['rabbitmq']['arch'] attribute
- add ['rabbitmq']['release'] attribute
- update server recipe to use new attributes
- update recipe to use yum_package to allow use of arch attribute
