### PR TITLE
Fix typo in rabbitmq.config.erb template

### DIFF
--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -8,7 +8,7 @@
     {cluster_nodes, [<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>]},
 <% end %>
 <% if node['rabbitmq']['ssl'] -%>
-    {ssl_listeners, [<%= node['rabbitmq']['ssl_port'] %>']},
+    {ssl_listeners, [<%= node['rabbitmq']['ssl_port'] %>]},
     {ssl_options, [{cacertfile,"<%= node['rabbitmq']['ssl_cacert'] %>"},
                     {certfile,"<%= node['rabbitmq']['ssl_cert'] %>"},
                     {keyfile,"<%= node['rabbitmq']['ssl_key'] %>"},


### PR DESCRIPTION
Fix typo in rabbitmq.config.erb template, superflous single quote in ssl_port.
Without this fix rabbit.config looks like:
    {ssl_listeners, [5671]'},
that breaks rabbitmq start with message about absence of dot in the end of config file.
