### PR TITLE
[COOK-1873] adding set_user_tag action to the rabbittmq_user LWRP

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -64,3 +64,12 @@ action :clear_permissions do
     end
   end
 end
+
+action :set_user_tag do
+  execute "rabbitmqctl set_user_tags #{new_resource.user} #{new_resource.user_tag}" do
+    not_if "rabbitmqctl list_users | grep #{new_resource.user} | grep #{new_resource.user_tag}"
+    only_if "rabbitmqctl list_users | grep #{new_resource.user}"
+    Chef::Log.info "Setting RabbitMQ user tag '#{new_resource.user_tag}' on '#{new_resource.user}'"
+    new_resource.updated_by_last_action(true)
+  end
+end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -17,12 +17,13 @@
 # limitations under the License.
 #
 
-actions :add, :delete, :set_permissions, :clear_permissions
+actions :add, :delete, :set_permissions, :clear_permissions, :set_user_tag
 
 attribute :user, :kind_of => String, :name_attribute => true
 attribute :password, :kind_of => String
 attribute :vhost, :kind_of => String
 attribute :permissions, :kind_of => String
+attribute :user_tag, :kind_of => String
 
 def initialize(*args)
   super


### PR DESCRIPTION
The 'management' plugin for RabbitMQ extends the default permissions model, allowing users to be given arbitrary tags which grant the user a set of permissions. This change extends the rabbitmq_user LWRP to allow setting tags on existing users.
