### PR TITLE
Using :immediately in rabbitmq* templates breaks clustering

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -81,7 +81,7 @@ template "/etc/rabbitmq/rabbitmq-env.conf" do
   owner "root"
   group "root"
   mode 0644
-  notifies :restart, "service[rabbitmq-server]", :immediately
+  notifies :restart, "service[rabbitmq-server]"
 end
 
 template "/etc/rabbitmq/rabbitmq.config" do
@@ -89,7 +89,7 @@ template "/etc/rabbitmq/rabbitmq.config" do
   owner "root"
   group "root"
   mode 0644
-  notifies :restart, "service[rabbitmq-server]", :immediately
+  notifies :restart, "service[rabbitmq-server]"
 end
 
 if File.exists?(node['rabbitmq']['erlang_cookie_path'])


### PR DESCRIPTION
Changing the notifies timing in 7ac2faac2e87bfb4e14dd19ba69d4156f50db3e8 appears to have broken the auto clustering in rabbitmq. The reason being that restarting the system right away causes the mnesia database to contain data that is invalid, thereby leading to a Bad cookie value.

Reverting the :immediately appears to allow clustering to spin up correctly. I have validated that non-cluster configurations also spin up correctly.
