### PR TITLE
COOK-2153 Fixed idempotence issues with user LWRP

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -36,13 +36,13 @@ end
 action :set_permissions do
   if new_resource.vhost
     execute "rabbitmqctl set_permissions -p #{new_resource.vhost} #{new_resource.user} #{new_resource.permissions}" do
-      not_if "rabbitmqctl list_user_permissions | grep #{new_resource.user}"
+      not_if "rabbitmqctl list_user_permissions -p #{new_resource.vhost} #{new_resource.user}"
       Chef::Log.info "Setting RabbitMQ user permissions for '#{new_resource.user}' on vhost #{new_resource.vhost}."
       new_resource.updated_by_last_action(true)
     end
   else
     execute "rabbitmqctl set_permissions #{new_resource.user} #{new_resource.permissions}" do
-      not_if "rabbitmqctl list_user_permissions | grep #{new_resource.user}"
+      not_if "rabbitmqctl list_user_permissions #{new_resource.user}"
       Chef::Log.info "Setting RabbitMQ user permissions for '#{new_resource.user}'."
       new_resource.updated_by_last_action(true)
     end


### PR DESCRIPTION
By incorrectly I mean it was using incorrect combination of
list_user_permissions command which was making the LWRP to be
NON-idempotent and was setting the permissions when they already
have been set. According to docs the correct commands are:

list_user_permissions [-p <vhostpath>] <username>

ie. you MUST supply the username as it's a mandatory argument.

Examples:

[sensu] ~ $ sudo rabbitmqctl list_user_permissions |foo  
Error: invalid command 'list_user_permissions'
[sensu] ~ $ sudo rabbitmqctl list_user_permissions |sensu
Error: invalid command 'list_user_permissions'
[sensu] ~ $ sudo rabbitmqctl list_user_permissions sensu 
Listing permissions for user "sensu" ...
/sensu  .\*  .\*  .*
...done.
[sensu] ~ $ sudo rabbitmqctl list_user_permissions -p /sensu sensu
Listing permissions for user "sensu" ...
/sensu  .\*  .\*  .*
...done.
[sensu] ~ $
