### PR TITLE
COOK-2256 Be able to configure any plugin via attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,6 +50,10 @@ default['rabbitmq']['virtualhosts'] = []
 default['rabbitmq']['enabled_plugins'] = []
 default['rabbitmq']['disabled_plugins'] = []
 
+# custom configuration
+default['rabbitmq']['custom_conf'] = {}
+
+
 # SmartOS-specific defaults
 if node[:platform] == 'smartos'
   default['rabbitmq']['service_name'] = 'rabbitmq'

--- a/libraries/erlang.rb
+++ b/libraries/erlang.rb
@@ -1,0 +1,33 @@
+class Object
+  def to_erl(tab, indent)
+    prefix = tab * (indent+1)
+    newLine = "\n" + prefix
+    case self
+    when Hash
+      if self.size > 0
+      "[" + newLine + 
+        self.map {|(k,v)|
+          val = v.to_erl(tab, indent+1)
+          if val.lines.count  >1
+            "{#{k},"+ newLine+" #{val}}"
+          else
+            "{#{k}, #{val}}"
+          end
+      }.join("," + newLine) +
+        newLine +"]"
+      else
+        p = self.each.first
+        '[{' + p[0] + ',' + p[1].to_erl(tab, indent+1) + "}]" + newLine
+      end
+    when Array
+      '[' + self.map{|v| v.to_erl(tab, indent+1)}.join(",")  +']'
+    when TrueClass then "true"
+    when FalseClass then "false"
+    when Integer then self.to_s
+    when String then "\"#{self}\""
+    when Symbol then self.to_s
+    else
+      raise "Don't know how to erlify #{self}"
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -82,3 +82,10 @@ attribute "rabbitmq/disabled_plugins",
   :description => "List all plugins that will be deactivated",
   :default => [],
   :type => "array"
+
+
+attribute "rabbitmq/custom_conf",
+  :description => "Custom configuration that will be merged into rabbitmq.config file",
+  :display_name => "Custom configuration",
+  :default => {},
+  :type => "hash"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -84,8 +84,16 @@ when "smartos"
   service node['rabbitmq']['service_name'] do
     action :start
   end
-
 end
+
+
+custom_conf = Hash.new
+%w(custom_conf).each do |a|
+  node[:rabbitmq][a].to_hash.each do |k,v|
+    custom_conf[k] = v.to_erl("  ", 0)
+  end
+end
+
 
 template "#{node['rabbitmq']['config_root']}/rabbitmq-env.conf" do
   source "rabbitmq-env.conf.erb"
@@ -100,6 +108,9 @@ template "#{node['rabbitmq']['config_root']}/rabbitmq.config" do
   owner "root"
   group "root"
   mode 00644
+  variables({
+    :custom_conf => custom_conf
+  })
   notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
 end
 

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -24,4 +24,7 @@
     {default_user, <<"<%= node['rabbitmq']['default_user'] %>">>},
     {default_pass, <<"<%= node['rabbitmq']['default_pass'] %>">>}
   ]}
+<% @custom_conf.each do |k,v|  -%>
+<%= ",{#{k}, #{v}}"  %>
+<% end %>
 ].


### PR DESCRIPTION
Example of use in an other cookbook
node.set[:rabbitmq][:custom_conf][:rabbitmq_mochiweb] = {:listeners => {:mgmt => {:ip => node[:ipaddress] , :port => 15672}}}

or can simply statically be set in a role (for shovel configuration for instance) 
