### PR TITLE
Add max_open_files to conf for debian

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,3 +66,6 @@ if node[:platform] == 'smartos'
   default['rabbitmq']['config'] = '/opt/local/etc/rabbitmq/rabbitmq'
   default['rabbitmq']['erlang_cookie_path'] = '/var/db/rabbitmq/.erlang.cookie'
 end
+
+# Debian
+default['rabbitmq']['max_open_files'] = '1024'

--- a/templates/default/rabbitmq-env.conf.erb
+++ b/templates/default/rabbitmq-env.conf.erb
@@ -8,3 +8,4 @@
 <% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= node['rabbitmq']['config'] %><% end %>
 <% if node['rabbitmq']['logdir'] -%>LOG_BASE=<%= node['rabbitmq']['logdir'] %><% end %>
 <% if node['rabbitmq']['mnesiadir'] -%>MNESIA_BASE=<%= node['rabbitmq']['mnesiadir'] %><% end %>
+<% if node['platform_family'] == 'debian' -%>ulimit -n <%= node['rabbitmq']['max_open_files'] %><% end %>


### PR DESCRIPTION
One may require the ability to adjust rabbitmq user open file limit.  On Debian/Ubuntu, the proper way is to use the conf file per the following: http://www.rabbitmq.com/install-debian.html#debian-system-limits

Added default 'max_open_files' attribute which is used in rabbitmq-env.conf if 'platform_family' is 'debian'
