### PR TITLE
[COOK-2830] Use a notify for server restart, instead of defining a new service

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -101,9 +101,9 @@ else
 end
 
 if node['rabbitmq']['cluster'] && (node['rabbitmq']['erlang_cookie'] != existing_erlang_key)
-  service "stop #{node['rabbitmq']['service_name']}" do
-    service_name node['rabbitmq']['service_name']
-    action :stop
+  log "stopping service[#{node['rabbitmq']['service_name']}] to change erlang_cookie" do
+    level :info
+    notifies :stop, "service[#{node['rabbitmq']['service_name']}]", :immediately
   end
 
   template node['rabbitmq']['erlang_cookie_path'] do


### PR DESCRIPTION
Fix for http://tickets.opscode.com/browse/COOK-2830
