### PR TITLE
added support to install packages from upstream debian repo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -58,6 +58,7 @@ default['rabbitmq']['disabled_plugins'] = []
 #platform specific settings
 case node['platform_family']
 when 'debian'
+  default['rabbitmq']['use_upstream_repo'] = false
   default['rabbitmq']['package'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
 when 'rhel'
   default['rabbitmq']['package'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ recipe            "rabbitmq::plugin_management", "Manage plugins with node attri
 recipe            "rabbitmq::virtualhost_management", "Manage virtualhost with node attributes"
 recipe            "rabbitmq::user_management", "Manage users with node attributes"
 depends           "erlang", ">= 0.9"
+depends           "apt", ">= 1.9"
 
 %w{ubuntu debian linuxmint redhat centos scientific amazon fedora oracle smartos}.each do |os|
   supports os

--- a/recipes/debian_repo.rb
+++ b/recipes/debian_repo.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: rabbitmq
+# Recipe:: default
+#
+# Copyright 2009, Benjamin Black
+# Copyright 2009-2013, Opscode, Inc.
+# Copyright 2012, Kevin Nuckolls <kevin.nuckolls@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apt_repository "rabbitmq" do
+  uri "http://www.rabbitmq.com/debian/"
+  distribution "testing"
+  components ["main"]
+  key "http://www.rabbitmq.com/rabbitmq-signing-key-public.asc"
+  action :add
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,9 +25,15 @@ case node['platform_family']
 when 'debian'
   # installs the required setsid command -- should be there by default but just in case
   package 'util-linux'
-
+  
+  if node['rabbitmq']['use_upstream_repo']
+    
+    include_recipe 'rabbitmq::debian_repo' 
+  
+  end
+  
   if node['rabbitmq']['use_distro_version']
-
+  
     package 'rabbitmq-server'
 
   else


### PR DESCRIPTION
I added a repository and an attribute to be able to use rabbitmq upstream repository for debian-based distribution.

By default the behavior is unchanged.
If the use set the attribute ['rabbitmq']['use_upstream_repo'] to true, then a repository will be added and the package installed from this repository.
