### PR TITLE
[COOK-3011] Apt Source Test Causes Chef Run to Fail on Ubuntu

### DIFF
--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -19,7 +19,7 @@ require File.expand_path('../support/helpers', __FILE__)
 describe "rabbitmq::default" do
   include Helpers::RabbitMQ
 
-  it 'installs the package from downloaded deb package on debian family' do
+  it 'installs the package from downloaded deb on debian family' do
     unless node['platform_family'] == 'debian'
       skip "Only applicable on Debian family"
     end


### PR DESCRIPTION
Seeing an error when running this cookbook on Ubuntu Precise:

 2) Failure:
rabbitmq::default#test_0001_uses the rabbitmq apt source on debian family [/var/chef/minitest/rabbitmq/default_test.rb:27]:
Expected path '/etc/apt/sources.list.d/rabbitmq-source.list' to exist

The test seems to be looking for a non-existent apt source repo. I've updated the test to look for the downloaded .deb file instead
