### PR TITLE
[COOK-3078] Escape and quote password before using

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -76,6 +76,11 @@ action :add do
     if new_resource.password.nil? || new_resource.password.empty?
       Chef::Application.fatal!("rabbitmq_user with action :add requires a non-nil/empty password.")
     end
+    # To escape single quotes in a shell, you have to close the surrounding single quotes, add
+    # in an escaped single quote, and then re-open the original single quotes.
+    # Since this string is interpolated once by ruby, and then a second time by the shell, we need
+    # to escape the escape character ('\') twice.  This is why the following is such a mess
+    # of leaning toothpicks:
     new_password = new_resource.password.gsub("'", "'\\\\''")
     cmdStr = "rabbitmqctl add_user #{new_resource.user} '#{new_password}'"
     execute cmdStr do


### PR DESCRIPTION
The password is not quoted in the add_user command, so any password with spaces will fail with "invalid command" due to too many arguments.  This adds quotes around the password, and of course escapes any quotes inside the password.
