### PR TITLE
[COOK-3079] Use word-boundaries to delimit in permission grep

### DIFF
--- a/providers/user.rb
+++ b/providers/user.rb
@@ -52,7 +52,7 @@ end
 # empty perm_list means we're checking for any permissions
 def user_has_permissions?(name, vhost, perm_list = nil)
   vhost = '/' if vhost.nil?
-  cmdStr = "rabbitmqctl -q list_user_permissions #{name} | grep \"^#{vhost}\\s\""
+  cmdStr = "rabbitmqctl -q list_user_permissions #{name} | grep \"^#{vhost}\\b\""
   cmd = Mixlib::ShellOut.new(cmdStr)
   cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
   cmd.run_command


### PR DESCRIPTION
`list_user_permissions` is using `\s` to delimit the vhost in its grep.  This does not correctly match, and is in fact inconsistent with the way the other greps in the cookbook - they all use `\b` (i.e. check for word boundary), which is more correct.

This updates the grep to use `\b`.
