### PR TITLE
RabbitMQ - Error in rabbitmq.config.erb template results in misconfiguration of cluster_nodes config entry and failure of cookbook to configure cluster 

### DIFF
--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -8,7 +8,11 @@
 <% end %>
   {rabbit, [
 <% if node['rabbitmq']['cluster'] && node['rabbitmq']['cluster_disk_nodes'] -%>
-    {cluster_nodes, {[<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>], disc}},
+	<% if node[:rabbitmq][:version] > '3.0.0' %>
+		{cluster_nodes, {[<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>], disc}},
+		<% else %>
+		{cluster_nodes, [<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>]},
+    <% end %>
 <% end %>
 <% if node['rabbitmq']['ssl'] -%>
     {ssl_listeners, [<%= node['rabbitmq']['ssl_port'] %>]},


### PR DESCRIPTION
The current rabbitmq.config.erb template does not result in a properly formatted cluster_nodes entry in the rabbitmq.config file as per RabbitMq docs[1]. 

Cookbook: 
https://github.com/opscode-cookbooks/rabbitmq

File: 
https://github.com/opscode-cookbooks/rabbitmq/blob/master/templates/default/rabbitmq-env.conf.erb

Change required:
{code} {cluster_nodes, [<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>]}, {code}

to

{code} {cluster_nodes, {[<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>], disc}}, {code}

References:
[1] http://www.rabbitmq.com/clustering.html
