### PR TITLE
Configure bind and cluster over the specified addr

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,9 @@ default['rabbitmq']['default_pass'] = 'guest'
 # bind erlang networking to localhost
 default['rabbitmq']['local_erl_networking'] = false
 
+# bind rabbit and erlang networking to an address
+default['rabbitmq']['erl_networking_bind_address'] = nil
+
 #clustering
 default['rabbitmq']['cluster'] = false
 default['rabbitmq']['cluster_disk_nodes'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -99,3 +99,6 @@ attribute "rabbitmq/local_erl_networking",
   :display_name => "Local Erlang networking",
   :description => "Bind erlang networking to localhost"
 
+attribute "rabbitmq/erl_networking_bind_address",
+  :display_name => "Erl Networking Bind Address",
+  :description => "Bind Rabbit and erlang networking to an address"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -138,4 +138,3 @@ if node['rabbitmq']['cluster'] && (node['rabbitmq']['erlang_cookie'] != existing
     action :nothing
   end
 end
-

--- a/templates/default/rabbitmq-env.conf.erb
+++ b/templates/default/rabbitmq-env.conf.erb
@@ -4,11 +4,16 @@
 
 <% if node['rabbitmq']['local_erl_networking'] -%>
 NODENAME=rabbit@localhost
+NODE_IP_ADDRESS=127.0.0.1
 export ERL_EPMD_ADDRESS=127.0.0.1
-<% else %>
-<% if node['rabbitmq']['nodename'] -%>NODENAME=<%= node['rabbitmq']['nodename'] %><% end %>
-<% end %>
+<% elsif node['rabbitmq']['erl_networking_bind_address'] -%>
+NODENAME=<%= node['rabbitmq']['nodename'] %>
+NODE_IP_ADDRESS=<%= node['rabbitmq']['erl_networking_bind_address'] %>
+export ERL_EPMD_ADDRESS=<%= node['rabbitmq']['erl_networking_bind_address'] %>
+<% else -%>
 <% if node['rabbitmq']['address'] -%>NODE_IP_ADDRESS=<%= node['rabbitmq']['address'] %><% end %>
+<% if node['rabbitmq']['nodename'] -%>NODENAME=<%= node['rabbitmq']['nodename'] %><% end %>
+<% end -%>
 <% if node['rabbitmq']['port'] -%>NODE_PORT=<%= node['rabbitmq']['port'] %><% end %>
 <% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= node['rabbitmq']['config'] %><% end %>
 <% if node['rabbitmq']['logdir'] -%>LOG_BASE=<%= node['rabbitmq']['logdir'] %><% end %>

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -5,6 +5,8 @@
 [
 <% if node['rabbitmq']['local_erl_networking'] %>
   {kernel, [{inet_dist_use_interface,{127,0,0,1}}]},
+<% elsif node['rabbitmq']['erl_networking_bind_address'] -%>
+  {kernel, [{inet_dist_use_interface,{<%= node['rabbitmq']['erl_networking_bind_address'].gsub(/\./, ',') %>}}]},
 <% end %>
   {rabbit, [
 <% if node['rabbitmq']['cluster'] && node['rabbitmq']['cluster_disk_nodes'] -%>


### PR DESCRIPTION
This patch allows for binding rabbit and epmd to the specified
address.  Useful when wanting to cluster over a different interface.
In our case we want clustering to occur over our reliable 20Gb network,
vs our management network.

There are a couple prerequisites to this configuration:
- The address provided to `rabbitmq['erl_networking_bind_address']`,
  requires f/rDNS.
- The hosts provided to `rabbitmq['cluster_disk_nodes']`, must resolve
  to IPs on the same network as `rabbitmq['erl_networking_bind_address']`.

Sample configuration, wanting to cluster over eth1.
  host1:
    - eth0 - 192.168.0.10 (host1)
    - eth1 - 172.16.0.10 (host1-ops)
  host2:
    - eth0 - 192.168.0.11 (host2)
    - eth1 - 172.16.0.11 (host2-ops)

Configure your wrapper cookbook such that:

  `node.override['rabbitmq']['erl_networking_bind_address']` = #{eth1_address}
  `node.override['rabbitmq']['nodename']` = "rabbit@host1-ops" or "rabbit@host2-ops"

... and if clustering:

  `node.override['rabbitmq']['cluster_disk_nodes']`= ["rabbit@host1-ops", "rabbit@host2-ops"]

Change-Id: Ib815e8fdf50dad7ea47e2484e93599fa631b4e6f
