### PR TITLE
Add attribute to set open file limit

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,7 @@ default['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
 # resource usage
 default['rabbitmq']['disk_free_limit_relative'] = nil
 default['rabbitmq']['vm_memory_high_watermark'] = nil
+default['rabbitmq']['open_file_limit'] = nil
 
 #ssl
 default['rabbitmq']['ssl'] = false

--- a/templates/default/rabbitmq-env.conf.erb
+++ b/templates/default/rabbitmq-env.conf.erb
@@ -13,3 +13,5 @@ export ERL_EPMD_ADDRESS=127.0.0.1
 <% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= node['rabbitmq']['config'] %><% end %>
 <% if node['rabbitmq']['logdir'] -%>LOG_BASE=<%= node['rabbitmq']['logdir'] %><% end %>
 <% if node['rabbitmq']['mnesiadir'] -%>MNESIA_BASE=<%= node['rabbitmq']['mnesiadir'] %><% end %>
+
+<% if node['rabbitmq']['open_file_limit'] -%>ulimit -n <%= node['rabbitmq']['open_file_limit'] %><% end %>


### PR DESCRIPTION
Setting the open file limits for RabbitMQ can be non-trivial as it does not always honor limits.conf. This commit adds attributes to set the open file limit with `ulimit -n` in the RabbitMQ environment file.

See http://lists.rabbitmq.com/pipermail/rabbitmq-discuss/2013-January/024990.html for more info.
