### PR TITLE
Added the capability to disable non-SSL connections to RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The cluster recipe is now combined with the default and will now auto-cluster. S
 
 To enable SSL turn `ssl` to `true` and set the paths to your cacert, cert and key files.
 
+To only allow SSL connections from clients, set `ssl_only` to `true`.
+
 Resources/Providers
 ===================
 There are 3 LWRPs for interacting with RabbitMQ.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -43,6 +43,7 @@ default['rabbitmq']['ssl_cert'] = '/path/to/cert.pem'
 default['rabbitmq']['ssl_key'] = '/path/to/key.pem'
 default['rabbitmq']['ssl_verify'] = 'verify_none'
 default['rabbitmq']['ssl_fail_if_no_peer_cert'] = false
+default['rabbitmq']['ssl_only'] = false
 
 #virtualhosts
 default['rabbitmq']['virtualhosts'] = []

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -10,6 +10,9 @@
 <% if node['rabbitmq']['cluster'] && node['rabbitmq']['cluster_disk_nodes'] -%>
     {cluster_nodes, [<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>]},
 <% end %>
+<% if node['rabbitmq']['ssl_only'] -%>
+    {tcp_listeners, []},
+<% end %>
 <% if node['rabbitmq']['ssl'] -%>
     {ssl_listeners, [<%= node['rabbitmq']['ssl_port'] %>]},
     {ssl_options, [{cacertfile,"<%= node['rabbitmq']['ssl_cacert'] %>"},


### PR DESCRIPTION
Added the capability to disable non-SSL connections to RabbitMQ. This is to cater for the environment where security requirements are very stringent and any non-SSL connection to the RabbitMQ server is not allowed.
