### PR TITLE
[COOK-3601] Fixes to get SmartOS working again

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,10 +29,16 @@ default['rabbitmq']['local_erl_networking'] = false
 # bind rabbit and erlang networking to an address
 default['rabbitmq']['erl_networking_bind_address'] = nil
 
+# general shell execution retry defaults
+default['rabbitmq']['execute_retries'] = 0
+default['rabbitmq']['execute_retry_delay'] = 2
+
 #clustering
 default['rabbitmq']['cluster'] = false
 default['rabbitmq']['cluster_disk_nodes'] = []
-default['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
+default['rabbitmq']['cluster_restart_retries'] = 6
+default['rabbitmq']['cluster_restart_retry_delay'] = 10
+default['rabbitmq']['erlang_cookie'] = 'NOTSET'
 
 # resource usage
 default['rabbitmq']['disk_free_limit_relative'] = nil
@@ -65,10 +71,12 @@ default['rabbitmq']['virtualhosts'] = []
 default['rabbitmq']['disabled_virtualhosts'] = []
 
 #users
-default['rabbitmq']['enabled_users'] =
-  [{ :name => "guest", :password => "guest", :rights =>
-    [{:vhost => nil , :conf => ".*", :write => ".*", :read => ".*"}]
-  }]
+# e.g.
+#  default['rabbitmq']['enabled_users'] =
+#    [{ :name => "guest", :password => "guest", :rights =>
+#      [{:vhost => nil , :conf => ".*", :write => ".*", :read => ".*"}]
+#    }]
+default['rabbitmq']['enabled_users'] = []
 default['rabbitmq']['disabled_users'] =[]
 
 #plugins
@@ -85,7 +93,10 @@ when 'smartos'
   default['rabbitmq']['service_name'] = 'rabbitmq'
   default['rabbitmq']['config_root'] = '/opt/local/etc/rabbitmq'
   default['rabbitmq']['config'] = '/opt/local/etc/rabbitmq/rabbitmq'
+  default['rabbitmq']['mnesiadir'] = '/var/db/rabbitmq/mnesia'
   default['rabbitmq']['erlang_cookie_path'] = '/var/db/rabbitmq/.erlang.cookie'
+  default['rabbitmq']['execute_retries'] = 6
+  default['rabbitmq']['execute_retry_delay'] = 10
 end
 
 # Example HA policies

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -43,7 +43,7 @@ def user_has_tag?(name, tag)
   begin
     cmd.error!
     true
-  rescue Exception => e
+  rescue Exception
     false
   end
 end
@@ -76,6 +76,12 @@ action :add do
     if new_resource.password.nil? || new_resource.password.empty?
       Chef::Application.fatal!("rabbitmq_user with action :add requires a non-nil/empty password.")
     end
+
+    execute "ensure root erlang cookie exists for #{new_resource.user}" do
+      command 'true'
+      notifies :create, 'template[/root/.erlang.cookie]', :immediately
+    end
+
     # To escape single quotes in a shell, you have to close the surrounding single quotes, add
     # in an escaped single quote, and then re-open the original single quotes.
     # Since this string is interpolated once by ruby, and then a second time by the shell, we need
@@ -85,6 +91,8 @@ action :add do
     cmdStr = "rabbitmqctl add_user #{new_resource.user} '#{new_password}'"
     execute "rabbitmqctl add_user #{new_resource.user}" do
       command cmdStr
+      retries node['rabbitmq']['execute_retries']
+      retry_delay node['rabbitmq']['execute_retry_delay']
       Chef::Log.info "Adding RabbitMQ user '#{new_resource.user}'."
       new_resource.updated_by_last_action(true)
     end
@@ -95,6 +103,8 @@ action :delete do
   if user_exists?(new_resource.user)
     cmdStr = "rabbitmqctl delete_user #{new_resource.user}"
     execute cmdStr do
+      retries node['rabbitmq']['execute_retries']
+      retry_delay node['rabbitmq']['execute_retry_delay']
       Chef::Log.debug "rabbitmq_user_delete: #{cmdStr}"
       Chef::Log.info "Deleting RabbitMQ user '#{new_resource.user}'."
       new_resource.updated_by_last_action(true)
@@ -111,6 +121,8 @@ action :set_permissions do
     vhostOpt = "-p #{new_resource.vhost}" unless new_resource.vhost.nil?
     cmdStr = "rabbitmqctl set_permissions #{vhostOpt} #{new_resource.user} \"#{perm_list.join("\" \"")}\""
     execute cmdStr do
+      retries node['rabbitmq']['execute_retries']
+      retry_delay node['rabbitmq']['execute_retry_delay']
       Chef::Log.debug "rabbitmq_user_set_permissions: #{cmdStr}"
       Chef::Log.info "Setting RabbitMQ user permissions for '#{new_resource.user}' on vhost #{new_resource.vhost}."
       new_resource.updated_by_last_action(true)
@@ -126,6 +138,8 @@ action :clear_permissions do
     vhostOpt = "-p #{new_resource.vhost}" unless new_resource.vhost.nil?
     cmdStr = "rabbitmqctl clear_permissions #{vhostOpt} #{new_resource.user}"
     execute cmdStr do
+      retries node['rabbitmq']['execute_retries']
+      retry_delay node['rabbitmq']['execute_retry_delay']
       Chef::Log.debug "rabbitmq_user_clear_permissions: #{cmdStr}"
       Chef::Log.info "Clearing RabbitMQ user permissions for '#{new_resource.user}' from vhost #{new_resource.vhost}."
       new_resource.updated_by_last_action(true)
@@ -140,6 +154,8 @@ action :set_tags do
   unless user_has_tag?(new_resource.user, new_resource.tag)
     cmdStr = "rabbitmqctl set_user_tags #{new_resource.user} #{new_resource.tag}"
     execute cmdStr do
+      retries node['rabbitmq']['execute_retries']
+      retry_delay node['rabbitmq']['execute_retry_delay']
       Chef::Log.debug "rabbitmq_user_set_tags: #{cmdStr}"
       Chef::Log.info "Setting RabbitMQ user '#{new_resource.user}' tags '#{new_resource.tag}'"
       new_resource.updated_by_last_action(true)
@@ -154,6 +170,8 @@ action :clear_tags do
   unless user_has_tag?(new_resource.user, '"\[\]"')
     cmdStr = "rabbitmqctl set_user_tags #{new_resource.user}"
     execute cmdStr do
+      retries node['rabbitmq']['execute_retries']
+      retry_delay node['rabbitmq']['execute_retry_delay']
       Chef::Log.debug "rabbitmq_user_clear_tags: #{cmdStr}"
       Chef::Log.info "Clearing RabbitMQ user '#{new_resource.user}' tags."
       new_resource.updated_by_last_action(true)

--- a/recipes/plugin_management.rb
+++ b/recipes/plugin_management.rb
@@ -34,3 +34,10 @@ node['rabbitmq']['disabled_plugins'].each do |plugin|
     notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
   end
 end
+
+file "#{node['rabbitmq']['config_root']}/enabled_plugins" do
+  mode 0644
+  owner 'rabbitmq'
+  group 'rabbitmq'
+  action :touch
+end

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -9,8 +9,8 @@
   {kernel, [{inet_dist_use_interface,{<%= node['rabbitmq']['erl_networking_bind_address'].gsub(/\./, ',') %>}}]},
 <% end %>
   {rabbit, [
-<% if node['rabbitmq']['cluster'] && node['rabbitmq']['cluster_disk_nodes'] -%>
-    {cluster_nodes, [<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>]},
+<% if node['rabbitmq']['cluster'] && node['rabbitmq']['cluster_disk_nodes'] && !node['rabbitmq']['cluster_disk_nodes'].empty? -%>
+    {cluster_nodes, {[<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>], disc}},
 <% end %>
 <% if node['rabbitmq']['ssl'] -%>
     {ssl_listeners, [<%= node['rabbitmq']['ssl_port'] %>]},


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3601
- Updating mnesiadir attribute and copying erlang cookie to /root
  so that things work again on SmartOS.
- Reading the erlang cookie file only if it's there
- More tweaks to get user and plugin management working (again) on SmartOS
- Tweaks to clustering setup, plus still fighting with epmd
- Fixing a goof in the rabbitmq.config template
  and de-duping definition of the /root/.erlang.cookie template.
- Making some repeated resources unique so that they don't overlap
- Removing a bunch of defaults so that DeepMerge from data bags works as expected
- Making cluster disk node configuration true to its name
