### PR TITLE
[COOK-3633] Adding not_if for stopping action during updating erlang cookie

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -171,6 +171,7 @@ if node['rabbitmq']['cluster'] && (node['rabbitmq']['erlang_cookie'] != existing
   log "stopping service[#{node['rabbitmq']['service_name']}] to change erlang_cookie" do
     level :info
     notifies :stop, "service[#{node['rabbitmq']['service_name']}]", :immediately
+    not_if "cat #{node['rabbitmq']['erlang_cookie_path']} | grep #{node['rabbitmq']['erlang_cookie']}"
   end
 
   template node['rabbitmq']['erlang_cookie_path'] do


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3633

It is needed ,because of every time service stopping during chef-client process, even if cluster already configured... 
So if we already have "good" erlang cookie, we doesn't need to stop service. 

Please merge it as soon , as possible!
