### PR TITLE
Make tcp listeners optional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,6 +55,7 @@ default['rabbitmq']['web_console_ssl'] = false
 default['rabbitmq']['web_console_ssl_port'] = 15671
 
 #tcp listen options
+default['rabbitmq']['tcp'] = true
 default['rabbitmq']['tcp_listen_packet'] = 'raw'
 default['rabbitmq']['tcp_listen_reuseaddr']  = true
 default['rabbitmq']['tcp_listen_backlog'] = 128

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -27,12 +27,16 @@
                     {verify,<%= node['rabbitmq']['ssl_verify'] %>},
                     {fail_if_no_peer_cert,<%= node['rabbitmq']['ssl_fail_if_no_peer_cert'] %>}]},
 <% end %>
+<% if node['rabbitmq']['tcp'] -%>
     {tcp_listen_options, [binary, {packet,<%= node['rabbitmq']['tcp_listen_packet'] %>},
                                   {reuseaddr,<%= node['rabbitmq']['tcp_listen_reuseaddr'] %>},
                                   {backlog,<%= node['rabbitmq']['tcp_listen_backlog'] %>},
                                   {nodelay,<%= node['rabbitmq']['tcp_listen_nodelay'] %>},
                                   {exit_on_close,<%= node['rabbitmq']['tcp_listen_exit_on_close'] %>},
                                   {keepalive,<%= node['rabbitmq']['tcp_listen_keepalive'] %>}]},
+<% else -%>
+   {tcp_listeners, []},
+<% end %>
 <% if node['rabbitmq']['disk_free_limit_relative'] -%>
     {disk_free_limit, {mem_relative, <%= node['rabbitmq']['disk_free_limit_relative'] %>}},
 <% end %>


### PR DESCRIPTION
This patch makes the tcp listeners optional.  This is useful when all rabbit connections should be made over SSL.
