### PR TITLE
[COOK-4279] Added ssl_opts in the rabbitmq_management configuration section when SSL...

### DIFF
--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -11,7 +11,10 @@
 <% if node['rabbitmq']['web_console_ssl'] -%>
   {rabbitmq_management, [
     {listener, [{port, <%= node['rabbitmq']['web_console_ssl_port'] %>},
-                {ssl, true}
+                {ssl, true},
+                {ssl_opts, [{cacertfile,"<%= node['rabbitmq']['ssl_cacert'] %>"},
+                    {certfile,"<%= node['rabbitmq']['ssl_cert'] %>"},
+                    {keyfile,"<%= node['rabbitmq']['ssl_key'] %>"}]}
               ]}
   ]},
 <% end %>


### PR DESCRIPTION
The rabbitmq_management plugin requires the SSL options when the web_console_ssl is enabled. 

This patch just adds the ssl_opts field in the rabbitmq.config template.
