### PR TITLE
[COOK-4280] Upstart script properly waits until the server is started.

### DIFF
--- a/templates/default/rabbitmq.upstart.conf.erb
+++ b/templates/default/rabbitmq.upstart.conf.erb
@@ -6,6 +6,20 @@ respawn
 respawn limit 5 60
 
 env HOME=""
+env RABBITMQ_PID_FILE="/var/run/rabbitmq/pid"
+
+pre-start script
+    PID_DIR=`dirname ${RABBITMQ_PID_FILE}`
+
+    if [ ! -d ${PID_DIR} ];
+    then
+        mkdir -p ${PID_DIR}
+        chown -R rabbitmq:rabbitmq ${PID_DIR}
+        chmod 755 ${PID_DIR}
+    fi
+end script
+
 exec /usr/sbin/rabbitmq-server > /var/log/rabbitmq/startup_log \
                               2> /var/log/rabbitmq/startup_err
-post-start exec /usr/sbin/rabbitmqctl wait >/dev/null 2>&1
+
+post-start exec /usr/sbin/rabbitmqctl wait $RABBITMQ_PID_FILE >/dev/null 2>&1


### PR DESCRIPTION
As described in this issue: https://tickets.opscode.com/browse/COOK-4280 the upstart script was wrongly emitting the `started` event.

Now the script behaves like the vendor init.d script and uses a custom pid file, then waits until the server is started.
