### PR TITLE
fixed argument error

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -163,9 +163,7 @@ template "#{node['rabbitmq']['config_root']}/rabbitmq.config" do
   owner 'root'
   group 'root'
   mode 00644
-  variables(
-    :kernel => format_kernel_parameters
-    )
+  variables(:kernel => format_kernel_parameters)
   notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
 end
 


### PR DESCRIPTION
This was being raised.

```
================================================================================
Recipe Compile Error in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/rabbitmq/recipes/default.rb
================================================================================

ArgumentError
-------------
You tried to set a nested key, where the parent is not a hash-like object: rabbitmq/kernel/inet_dist_use_interface/inet_dist_use_interface

Cookbook Trace:
---------------
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/rabbitmq/libraries/default.rb:35:in `select'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/rabbitmq/libraries/default.rb:35:in `format_kernel_parameters'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/rabbitmq/recipes/default.rb:167:in `from_file'
  /tmp/vagrant-chef-1/chef-solo-1/cookbooks/rabbitmq/recipes/default.rb:161:in `from_file'

Relevant File Content:
----------------------
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/rabbitmq/libraries/default.rb:

  1:  #
  2:  # Cookbook Name:: rabbitmq
  3:  # Library:: default
  4:  # Author:: Jake Davis (<jake@simple.com>)
  5:  #
  6:  # Licensed under the Apache License, Version 2.0 (the "License");
  7:  # you may not use this file except in compliance with the License.
  8:  # You may obtain a copy of the License at
  9:  #

[2014-02-18T20:28:19+00:00] ERROR: Running exception handlers
[2014-02-18T20:28:19+00:00] ERROR: Exception handlers complete
[2014-02-18T20:28:19+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2014-02-18T20:28:19+00:00] FATAL: ArgumentError: You tried to set a nested key, where the parent is not a hash-like object: rabbitmq/kernel/inet_dist_use_interface/inet_dist_use_interface
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```
