### PR TITLE
COOK-3036: Removed esl repository workaround, because esl repo is fixed for centos.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -89,7 +89,9 @@ when 'debian'
     end
   end
 
-if node['rabbitmq']['use_distro_version']
+
+when 'rhel', 'fedora'
+ if node['rabbitmq']['use_distro_version']
     package 'rabbitmq-server'
   else
     remote_file "#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm" do


### PR DESCRIPTION
Please remove the workaround for the esl repository, because the centos/redhat esl part is fixed now with erlang packages with the name erlang. Right now the esl part is broken until these lines are removed.

Thanks a lot and regards,

Olaf
