### PR TITLE
RPM / DEB package installs now use the rabbit version you specify

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,10 +81,6 @@ default['rabbitmq']['disabled_plugins'] = []
 
 # platform specific settings
 case node['platform_family']
-when 'debian'
-  default['rabbitmq']['package'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
-when 'rhel', 'fedora'
-  default['rabbitmq']['package'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
 when 'smartos'
   default['rabbitmq']['service_name'] = 'rabbitmq'
   default['rabbitmq']['config_root'] = '/opt/local/etc/rabbitmq'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,8 +35,10 @@ when 'debian'
   if node['rabbitmq']['use_distro_version']
     package 'rabbitmq-server'
   else
+    # we need to download the package
+    deb_package = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
     remote_file "#{Chef::Config[:file_cache_path]}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb" do
-      source node['rabbitmq']['package']
+      source deb_package
       action :create_if_missing
     end
     dpkg_package "#{Chef::Config[:file_cache_path]}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
@@ -101,8 +103,11 @@ when 'rhel', 'fedora'
   if node['rabbitmq']['use_distro_version']
     package 'rabbitmq-server'
   else
+    # We need to download the rpm
+    rpm_package = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
+
     remote_file "#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm" do
-      source node['rabbitmq']['package']
+      source rpm_package
       action :create_if_missing
     end
     rpm_package "#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"


### PR DESCRIPTION
Previously the version was ignored, and it would just download the default version of deb/rpm packages
This fix resolves the version in the recipe, not the attributes, so the version is resolved correctly.
