### PR TITLE
Avoid breaking this recipe on apt-get upgrade

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,6 +35,7 @@ when 'debian'
   package 'logrotate'
 
   if node['rabbitmq']['use_distro_version']
+    execute 'echo "rabbitmq-server install" | dpkg --set-selections'
     package 'rabbitmq-server'
   else
     # we need to download the package
@@ -43,6 +44,7 @@ when 'debian'
       source deb_package
       action :create_if_missing
     end
+    execute 'echo "rabbitmq-server hold" | dpkg --set-selections'
     dpkg_package "#{Chef::Config[:file_cache_path]}/rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
   end
 


### PR DESCRIPTION
By default `use_distro_version` is false. If you manually upgrade your servers (and you probably should to keep it up-to-date) rabbitmq-server would be upgraded (this is the case with Ubuntu 14.04 for instance) and often the downgrade is not possible so the recipe would fail to run after an upgrade until you do something like `dpkg --purge rabbitmq-server`.

When we install an specific package version we should also put it on hold to prevent `apt-get upgrade` to upgrade that particular package:

See "How do I put a package on hold" here: https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html

Or other ways here: http://askubuntu.com/questions/18654/how-to-prevent-updating-of-a-specific-package
