### PR TITLE
Ensure the rabbit node is started before attempting to reload the app when creating a cluster

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -197,10 +197,10 @@ if node['rabbitmq']['cluster'] && (node['rabbitmq']['erlang_cookie'] != existing
   end
 
   service "start #{node['rabbitmq']['service_name']}" do
-      service_name node['rabbitmq']['service_name']
-      pattern node['rabbitmq']['service_name']
-      action :start
-  end  
+    service_name node['rabbitmq']['service_name']
+    pattern node['rabbitmq']['service_name']
+    action :start
+  end
 
   # Need to reset for clustering #
   execute 'reset-node' do


### PR DESCRIPTION
Refactored the template action when setting the erlang cookie for a clustered node to ensure the service is restarted before attempting to stop and start the running application.

It is hard to debug but it would appear that the "notifies" method appears to run out of order and attempts to run the execute 'reset-node' before the service is fully stopped and restarted. Manually attempting to reset the node now fails as the running services cookies is different from the configured one.

I hope this looks ok?

Mark
