### PR TITLE
Explicitly use Chef::Provider::Service::Debian on Ubuntu/Debian

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,6 +48,7 @@ when 'debian'
   if node['rabbitmq']['job_control'] == 'upstart'
     # We start with stock init.d, remove it if we're not using init.d, otherwise leave it alone
     service node['rabbitmq']['service_name'] do
+      provider Chef::Provider::Service::Debian
       action [:stop]
       only_if { File.exists?('/etc/init.d/rabbitmq-server') }
     end
@@ -77,6 +78,7 @@ when 'debian'
 
   if node['rabbitmq']['job_control'] == 'initd'
     service node['rabbitmq']['service_name'] do
+      provider Chef::Provider::Service::Debian
       supports :status => true, :restart => true
       action [:enable, :start]
     end


### PR DESCRIPTION
The next version of Chef will use Chef::Provider::Service::Upstart by
default in Ubuntu 13.10+ [Changelog], [CHEF-5276]), because Ubuntu
stopped shipping compatibility links in /etc/init.d/ [bug], [wiki].

[Changelog] https://github.com/opscode/chef/blob/master/CHANGELOG.md
[CHEF-5276] https://tickets.opscode.com/browse/CHEF-5276
[bug] https://bugs.launchpad.net/ubuntu/+source/rsyslog/+bug/1311810/comments/4
[wiki] https://wiki.ubuntu.com/UpstartCompatibleInitScripts
