### PR TITLE
Make cluster nodes list more deterministic

### DIFF
--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -4,7 +4,7 @@
 
 [
   {kernel, [
-<%= @kernel %> 
+<%= @kernel %>
   ]},
 <% if node['rabbitmq']['web_console_ssl'] -%>
   {rabbitmq_management, [
@@ -18,7 +18,7 @@
 <% end %>
   {rabbit, [
 <% if node['rabbitmq']['cluster'] && node['rabbitmq']['cluster_disk_nodes'] -%>
-    {cluster_nodes, {[<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.join(',') %>], disc}},
+    {cluster_nodes, {[<%= node['rabbitmq']['cluster_disk_nodes'].map{|n| "\'#{n}\'"}.sort.join(',') %>], disc}},
     {cluster_partition_handling,<%= node['rabbitmq']['cluster_partition_handling'] %>},
 <% end %>
 <% if node['rabbitmq']['ssl'] -%>


### PR DESCRIPTION
I know this doesn't make much sense, but for some reason, I'm seeing `cluster_disk_node` come out in weird orders, thus causing unexpected restarts of the rabbitmq service. This just adds a sort to ensure the array is presented in a consistent state and avoid unnecessary restarts.
