### PR TITLE
update rabbitmq_policy definition to properly enter params

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sets or clears a rabbitmq policy.
 ```ruby
 rabbitmq_policy "ha-all" do
   pattern "^(?!amq\\.).*"
-  params {"ha-mode"=>"all"}
+  params ({"ha-mode"=>"all"})
   priority 1
   action :set
 end


### PR DESCRIPTION
rabbitmq_policy resource was not defining params properly.  This would error on run.  Submitted change is working properly.
