### PR TITLE
make config file template source cookbook configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,8 @@ default['rabbitmq']['service_name'] = 'rabbitmq-server'
 default['rabbitmq']['config_root'] = '/etc/rabbitmq'
 default['rabbitmq']['config'] = '/etc/rabbitmq/rabbitmq'
 default['rabbitmq']['erlang_cookie_path'] = '/var/lib/rabbitmq/.erlang.cookie'
+# override this if you wish to provide `rabbitmq.config.erb` in your own wrapper cookbook
+default['rabbitmq']['config_template_cookbook'] = 'rabbitmq'
 
 # rabbitmq.config defaults
 default['rabbitmq']['default_user'] = 'guest'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -156,6 +156,7 @@ end
 
 template "#{node['rabbitmq']['config_root']}/rabbitmq.config" do
   source 'rabbitmq.config.erb'
+  cookbook node['rabbitmq']['config_template_cookbook']
   owner 'root'
   group 'root'
   mode 00644


### PR DESCRIPTION
Allows the wrapper cookbook author to provide the `rabbitmq.config.erb` in their wrapper cookbook. This is necessary if you want to eg. add configuration for plugins.
