### PR TITLE
Adds policy apply_to option

### DIFF
--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -40,6 +40,7 @@ action :set do
   unless policy_exists?(new_resource.vhost, new_resource.policy)
     cmd = 'rabbitmqctl set_policy'
     cmd << " -p #{new_resource.vhost}" unless new_resource.vhost.nil?
+    cmd << " --apply-to #{new_resource.apply_to}" if new_resource.apply_to
     cmd << " #{new_resource.policy}"
     cmd << " \"#{new_resource.pattern}\""
     cmd << " '{"

--- a/resources/policy.rb
+++ b/resources/policy.rb
@@ -26,3 +26,4 @@ attribute :pattern, :kind_of => String
 attribute :params, :kind_of => Hash
 attribute :priority, :kind_of => Integer
 attribute :vhost, :kind_of => String
+attribute :apply_to, :kind_of => String, :equal_to => ['all', 'queues', 'exchanges']

--- a/test/cookbooks/rabbitmq_test/recipes/lwrps.rb
+++ b/test/cookbooks/rabbitmq_test/recipes/lwrps.rb
@@ -50,3 +50,10 @@ remote_file "/usr/local/bin/rabbitmqadmin" do
   mode "0755"
   action :create
 end
+
+rabbitmq_policy "rabbitmq_cluster" do
+  pattern 'cluster.*'
+  params 'ha-mode' => 'all', 'ha-sync-mode' => 'automatic'
+  apply_to 'queues'
+  action :set
+end

--- a/test/integration/lwrps/rspec/lwrps_spec.rb
+++ b/test/integration/lwrps/rspec/lwrps_spec.rb
@@ -8,3 +8,7 @@ end
 describe command('/usr/local/bin/rabbitmqadmin --version') do
   it { should return_exit_status 0 }
 end
+
+describe command('/usr/local/bin/rabbitmqctl list_policies') do
+  its(:stdout) { should match /\/\s+rabbitmq_cluster\s+queues\s+cluster\.\*\s+{"ha-mode":"all","ha-sync-mode":"automatic"}\s+0/ }
+end


### PR DESCRIPTION
When creating a policy with rabbitmqctl, you can set an --apply-to option, which can be 'all', 'exchanges', or 'queues'. For example, you may want to only apply a federation policy to queues.
This change adds that option to the `policy` lwrp.
