### PR TITLE
Updated the RuboCop camel case

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'kitchen'
 # Style tests. Rubocop and Foodcritic
 namespace :style do
   desc 'Run Ruby style checks'
-  Rubocop::RakeTask.new(:ruby)
+  RuboCop::RakeTask.new(:ruby)
 
   desc 'Run Chef style checks'
   FoodCritic::Rake::LintTask.new(:chef) do |t|
@@ -36,21 +36,21 @@ namespace :integration do
       instance.test(:always)
     end
   end
-  
+
   desc 'Run Test Kitchen with cloud plugins'
   task :cloud do
     run_kitchen = true
     if ENV['TRAVIS'] == 'true' && ENV['TRAVIS_PULL_REQUEST'] != 'false'
       run_kitchen = false
     end
-    
+
     if run_kitchen
       Kitchen.logger = Kitchen.default_file_logger
       @loader = Kitchen::Loader::YAML.new(project_config: './.kitchen.cloud.yml')
       config = Kitchen::Config.new( loader: @loader)
       config.instances.each do |instance|
-        instance.test(:always)      
-      end      
+        instance.test(:always)
+      end
     end
   end
 end


### PR DESCRIPTION
Answer is because Rubocop changed name to RuboCop (camel case) in
version 0.23.0.

https://gist.github.com/renier/9d23ead9a36ba2939d18
