### PR TITLE
Updated the RuboCop camel case

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source 'https://supermarket.getchef.com'
 
 metadata
 

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 group :unit do
   gem 'berkshelf'
   gem 'chefspec'
+  gem 'fauxhai'
 end
 
 group :kitchen_common do

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,8 +2,52 @@ require 'spec_helper'
 
 describe 'rabbitmq::default' do
   let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let(:file_cache_path) { Chef::Config[:file_cache_path] }
 
-  it 'installs logrotate' do
-    expect(chef_run).to install_package('logrotate')
+  version = '3.3.5'
+
+  it 'creates a directory for mnesiadir' do
+    expect(chef_run).to create_directory('/var/lib/rabbitmq/mnesia')
   end
+
+  it 'creates a template rabbitmq-env.conf with attributes' do
+    expect(chef_run).to create_template('/etc/rabbitmq/rabbitmq-env.conf').with(
+      :user => 'root',
+      :group => 'root',
+      :source => 'rabbitmq-env.conf.erb',
+      :mode => 00644)
+  end
+
+  it 'should create the directory /var/lib/rabbitmq/mnesia' do
+    expect(chef_run).to create_directory('/var/lib/rabbitmq/mnesia').with(
+     :user => 'rabbitmq',
+     :group => 'rabbitmq',
+     :mode => '775'
+   )
+  end
+
+  it 'enables a rabbitmq service' do
+    expect(chef_run).to enable_service('rabbitmq-server')
+  end
+
+  it 'start a rabbitmq service' do
+    expect(chef_run).to start_service('rabbitmq-server')
+  end
+
+  it 'creates a rabbitmq-server rpm in the cache path' do
+    expect(chef_run).to create_remote_file_if_missing("#{file_cache_path}/rabbitmq-server-#{version}-1.noarch.rpm")
+  end
+
+  it 'installs the rabbitmq-server rpm_package with the default action' do
+    expect(chef_run).to install_rpm_package("#{Chef::Config[:file_cache_path]}/rabbitmq-server-#{version}-1.noarch.rpm")
+  end
+
+  it 'creates a template rabbitmq.config with attributes' do
+    expect(chef_run).to create_template('/etc/rabbitmq/rabbitmq.config').with(
+      :user => 'root',
+      :group => 'root',
+      :source => 'rabbitmq.config.erb',
+      :mode => 00644)
+  end
+
 end

--- a/spec/mgmt_console_spec.rb
+++ b/spec/mgmt_console_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'rabbitmq::mgmt_console' do
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.default['rabbitmq'] = {
+        ['version'] => '3.3.5-1'
+      }
+    end.converge(described_recipe)
+  end
+
+  let(:file_cache_path) { Chef::Config[:file_cache_path] }
+
+  it 'includes the `default` recipe' do
+    expect(chef_run).to include_recipe('rabbitmq::default')
+  end
+
+end

--- a/spec/plugin_management_spec.rb
+++ b/spec/plugin_management_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'rabbitmq::plugin_management' do
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.default['rabbitmq'] = {
+        ['version'] => '3.3.5-1'
+      }
+    end.converge(described_recipe)
+  end
+
+  let(:file_cache_path) { Chef::Config[:file_cache_path] }
+
+  it 'includes the `default` recipe' do
+    expect(chef_run).to include_recipe('rabbitmq::default')
+  end
+
+end

--- a/spec/policy_management_spec.rb
+++ b/spec/policy_management_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'rabbitmq::policy_management' do
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.default['rabbitmq'] = {
+        ['version'] => '3.3.5-1'
+      }
+    end.converge(described_recipe)
+  end
+
+  let(:file_cache_path) { Chef::Config[:file_cache_path] }
+
+  it 'includes the `default` recipe' do
+    expect(chef_run).to include_recipe('rabbitmq::default')
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
+require 'fauxhai'
+ChefSpec::Coverage.start!
 
-at_exit { ChefSpec::Coverage.report! }
+RSpec.configure do |config|
+  config.platform = 'redhat'
+  config.version = '6.5'
+end

--- a/spec/user_management_spec.rb
+++ b/spec/user_management_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'rabbitmq::user_management' do
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.default['rabbitmq'] = {
+        ['version'] => '3.3.5-1'
+      }
+    end.converge(described_recipe)
+  end
+
+  let(:file_cache_path) { Chef::Config[:file_cache_path] }
+
+  it 'includes the `default` recipe' do
+    expect(chef_run).to include_recipe('rabbitmq::default')
+  end
+
+  it 'includes the `virtualhost_management` recipe' do
+    expect(chef_run).to include_recipe('rabbitmq::virtualhost_management')
+  end
+
+end

--- a/spec/virtualhost_management_spec.rb
+++ b/spec/virtualhost_management_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'rabbitmq::virtualhost_management' do
+  let(:chef_run) do
+    ChefSpec::Runner.new do |node|
+      node.default['rabbitmq'] = {
+        ['version'] => '3.3.5-1'
+      }
+    end.converge(described_recipe)
+  end
+
+  let(:file_cache_path) { Chef::Config[:file_cache_path] }
+
+  it 'includes the `default` recipe' do
+    expect(chef_run).to include_recipe('rabbitmq::default')
+  end
+
+end


### PR DESCRIPTION
Answer is because Rubocop changed name to RuboCop (camel case) in
version 0.23.0.

https://gist.github.com/renier/9d23ead9a36ba2939d18
