### PR TITLE
make node['rabbitmq']['version'] more wrapper friendly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,7 @@ MethodLength:
 
 Style/FileName:
   Enabled: false
+
+Style/FormatString:
+  Exclude:
+    - 'recipes/default.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,3 @@ MethodLength:
 
 Style/FileName:
   Enabled: false
-
-Style/FormatString:
-  Exclude:
-    - 'recipes/default.rb'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,11 +6,11 @@ default['rabbitmq']['use_distro_version'] = false
 default['rabbitmq']['pin_distro_version'] = false
 
 # provide options to override download urls and package names
-default['rabbitmq']['deb_package'] = "rabbitmq-server_%{version}-1_all.deb"
-default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v%{version}/"
+default['rabbitmq']['deb_package'] = 'rabbitmq-server_%{version}-1_all.deb'
+default['rabbitmq']['deb_package_url'] = 'https://www.rabbitmq.com/releases/rabbitmq-server/v%{version}/'
 
-default['rabbitmq']['rpm_package'] = "rabbitmq-server-%{version}-1.noarch.rpm"
-default['rabbitmq']['rpm_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v%{version}/"
+default['rabbitmq']['rpm_package'] = 'rabbitmq-server-%{version}-1.noarch.rpm'
+default['rabbitmq']['rpm_package_url'] = 'https://www.rabbitmq.com/releases/rabbitmq-server/v%{version}/'
 
 default['rabbitmq']['esl-erlang_package'] = 'esl-erlang-compat-R16B03-1.noarch.rpm?raw=true'
 default['rabbitmq']['esl-erlang_package_url'] = 'https://github.com/jasonmcintosh/esl-erlang-compat/blob/master/rpmbuild/RPMS/noarch/'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,11 +6,11 @@ default['rabbitmq']['use_distro_version'] = false
 default['rabbitmq']['pin_distro_version'] = false
 
 # provide options to override download urls and package names
-default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
-default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
+default['rabbitmq']['deb_package'] = "rabbitmq-server_%{version}-1_all.deb"
+default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v%{version}/"
 
-default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.noarch.rpm"
-default['rabbitmq']['rpm_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
+default['rabbitmq']['rpm_package'] = "rabbitmq-server-%{version}-1.noarch.rpm"
+default['rabbitmq']['rpm_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v%{version}/"
 
 default['rabbitmq']['esl-erlang_package'] = 'esl-erlang-compat-R16B03-1.noarch.rpm?raw=true'
 default['rabbitmq']['esl-erlang_package_url'] = 'https://github.com/jasonmcintosh/esl-erlang-compat/blob/master/rpmbuild/RPMS/noarch/'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,12 +57,12 @@ when 'debian'
     end
   else
     # we need to download the package
-    deb_package = "#{node['rabbitmq']['deb_package_url']}#{node['rabbitmq']['deb_package']}" % { version: node['rabbitmq']['version'] }
-    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" % { version: node['rabbitmq']['version'] } do
+    deb_package = "#{node['rabbitmq']['deb_package_url']}#{node['rabbitmq']['deb_package']}" % { :version => node['rabbitmq']['version'] }
+    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" % { :version => node['rabbitmq']['version'] } do
       source deb_package
       action :create_if_missing
     end
-    dpkg_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" % { version: node['rabbitmq']['version'] } do
+    dpkg_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" % { :version => node['rabbitmq']['version'] } do
       action :install
     end
   end
@@ -112,13 +112,13 @@ when 'rhel', 'fedora'
     end
   else
     # We need to download the rpm
-    rpm_package = "#{node['rabbitmq']['rpm_package_url']}#{node['rabbitmq']['rpm_package']}" % { version: node['rabbitmq']['version'] }
+    rpm_package = "#{node['rabbitmq']['rpm_package_url']}#{node['rabbitmq']['rpm_package']}" % { :version => node['rabbitmq']['version'] }
 
-    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" % { version: node['rabbitmq']['version'] } do
+    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" % { :version => node['rabbitmq']['version'] } do
       source rpm_package
       action :create_if_missing
     end
-    rpm_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" % { version: node['rabbitmq']['version'] }
+    rpm_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" % { :version => node['rabbitmq']['version'] }
   end
 
 when 'suse'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,12 +57,12 @@ when 'debian'
     end
   else
     # we need to download the package
-    deb_package = "#{node['rabbitmq']['deb_package_url']}#{node['rabbitmq']['deb_package']}"
-    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" do
+    deb_package = "#{node['rabbitmq']['deb_package_url']}#{node['rabbitmq']['deb_package']}" % { version: node['rabbitmq']['version'] }
+    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" % { version: node['rabbitmq']['version'] } do
       source deb_package
       action :create_if_missing
     end
-    dpkg_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" do
+    dpkg_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" % { version: node['rabbitmq']['version'] } do
       action :install
     end
   end
@@ -112,13 +112,13 @@ when 'rhel', 'fedora'
     end
   else
     # We need to download the rpm
-    rpm_package = "#{node['rabbitmq']['rpm_package_url']}#{node['rabbitmq']['rpm_package']}"
+    rpm_package = "#{node['rabbitmq']['rpm_package_url']}#{node['rabbitmq']['rpm_package']}" % { version: node['rabbitmq']['version'] }
 
-    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" do
+    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" % { version: node['rabbitmq']['version'] } do
       source rpm_package
       action :create_if_missing
     end
-    rpm_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}"
+    rpm_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" % { version: node['rabbitmq']['version'] }
   end
 
 when 'suse'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,12 +57,12 @@ when 'debian'
     end
   else
     # we need to download the package
-    deb_package = "#{node['rabbitmq']['deb_package_url']}#{node['rabbitmq']['deb_package']}" % { :version => node['rabbitmq']['version'] }
-    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" % { :version => node['rabbitmq']['version'] } do
+    deb_package = format("#{node['rabbitmq']['deb_package_url']}#{node['rabbitmq']['deb_package']}", :version => node['rabbitmq']['version'])
+    remote_file format("#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}", :version => node['rabbitmq']['version']) do
       source deb_package
       action :create_if_missing
     end
-    dpkg_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}" % { :version => node['rabbitmq']['version'] } do
+    dpkg_package format("#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['deb_package']}", :version => node['rabbitmq']['version']) do
       action :install
     end
   end
@@ -112,13 +112,13 @@ when 'rhel', 'fedora'
     end
   else
     # We need to download the rpm
-    rpm_package = "#{node['rabbitmq']['rpm_package_url']}#{node['rabbitmq']['rpm_package']}" % { :version => node['rabbitmq']['version'] }
+    rpm_package = format("#{node['rabbitmq']['rpm_package_url']}#{node['rabbitmq']['rpm_package']}", :version => node['rabbitmq']['version'])
 
-    remote_file "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" % { :version => node['rabbitmq']['version'] } do
+    remote_file format("#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}", :version => node['rabbitmq']['version']) do
       source rpm_package
       action :create_if_missing
     end
-    rpm_package "#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}" % { :version => node['rabbitmq']['version'] }
+    rpm_package format("#{Chef::Config[:file_cache_path]}/#{node['rabbitmq']['rpm_package']}", :version => node['rabbitmq']['version'])
   end
 
 when 'suse'


### PR DESCRIPTION
Currently, if you have a wrapper cookbook and you want to change the version, you'll need to change:
- `node['rabbitmq']['version']`
- `node['rabbitmq']['deb_package']`
-  `node['rabbitmq']['deb_package_url']`
- `node['rabbitmq']['rpm_package']`
- `node['rabbitmq']['rpm_package_url']`

instead of just `node['rabbitmq']['version']`
