### PR TITLE
replace logrotate script, for debian upstart

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -17,6 +17,7 @@ depends 'erlang'
 depends 'yum-epel'
 depends 'yum-erlang_solutions'
 depends 'dpkg_autostart'
+depends 'logrotate'
 
 supports 'centos', '>= 7.0'
 supports 'debian', '>= 8.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -83,6 +83,18 @@ when 'debian'
       action :delete
     end
 
+    include_recipe 'logrotate'
+
+    logrotate_app 'rabbitmq-server' do
+      path '/var/log/rabbitmq/*.log'
+      enable true
+      rotate 20
+      frequency 'weekly'
+      options ['missingok', 'notifempty', 'delaycompress']
+      sharedscripts true
+      postrotate '/usr/sbin/rabbitmqctl rotate_logs > /dev/null'
+    end
+
     template "/etc/init/#{node['rabbitmq']['service_name']}.conf" do
       source 'rabbitmq.upstart.conf.erb'
       owner 'root'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -90,7 +90,7 @@ when 'debian'
       enable true
       rotate 20
       frequency 'weekly'
-      options %w[missingok notifempty delaycompress]
+      options %w(missingok notifempty delaycompress)
       sharedscripts true
       postrotate '/usr/sbin/rabbitmqctl rotate_logs > /dev/null'
     end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -90,7 +90,7 @@ when 'debian'
       enable true
       rotate 20
       frequency 'weekly'
-      options ['missingok', 'notifempty', 'delaycompress']
+      options %w[missingok notifempty delaycompress]
       sharedscripts true
       postrotate '/usr/sbin/rabbitmqctl rotate_logs > /dev/null'
     end


### PR DESCRIPTION
### Problem

The debian rabbitmq-server package relies on `/etc/init.d/rabbitmq-server` to rotate logs. When installing rabbitmq-server, with upstart support, the init script is removed. This prevents the log files from properly rotating.
### Solution

Add logrotate cookbook, configure logrotate when debian upstart installs.
### Before

```
/var/log/rabbitmq/*.log {
        weekly
        missingok
        rotate 20
        compress
        delaycompress
        notifempty
        sharedscripts
        postrotate
            /etc/init.d/rabbitmq-server rotate-logs > /dev/null
        endscript
}
```
### After

```
# This file was generated by Chef for rabbitmq-24.staging.us-west-2.adaptly.com.
# Do not modify this file by hand!

"/var/log/rabbitmq/*.log" {
  weekly
  rotate 20
  missingok
  notifempty
  delaycompress
  sharedscripts
  postrotate
  /usr/sbin/rabbitmqctl rotate_logs > /dev/null
  endscript
}
```
