### PR TITLE
changes to support foodcritic...

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,6 @@ rabbitmq_cluster '[{"name":"rabbit@rabbit1","type":"disc"},{"name":"rabbit@rabbi
 end
 ```
 
-
 ## Limitations
 
 For an already running cluster, these actions still require manual intervention:

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -32,23 +32,21 @@ end
 use_inline_resources
 
 action :enable do
-  unless plugin_enabled?(new_resource.plugin)
-    execute "rabbitmq-plugins enable #{new_resource.plugin}" do
-      umask 0022
-      Chef::Log.info "Enabling RabbitMQ plugin '#{new_resource.plugin}'."
-      environment 'PATH' => "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
-      new_resource.updated_by_last_action(true)
-    end
+  execute "rabbitmq-plugins enable #{new_resource.plugin}" do
+    umask 0022
+    Chef::Log.info "Enabling RabbitMQ plugin '#{new_resource.plugin}'."
+    environment 'PATH' => "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
+    new_resource.updated_by_last_action(true)
+    not_if { plugin_enabled?(new_resource.plugin) }
   end
 end
 
 action :disable do
-  if plugin_enabled?(new_resource.plugin)
-    execute "rabbitmq-plugins disable #{new_resource.plugin}" do
-      umask 0022
-      Chef::Log.info "Disabling RabbitMQ plugin '#{new_resource.plugin}'."
-      environment 'PATH' => "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
-      new_resource.updated_by_last_action(true)
-    end
+  execute "rabbitmq-plugins disable #{new_resource.plugin}" do
+    umask 0022
+    Chef::Log.info "Disabling RabbitMQ plugin '#{new_resource.plugin}'."
+    environment 'PATH' => "#{ENV['PATH']}:/usr/lib/rabbitmq/bin"
+    new_resource.updated_by_last_action(true)
+    only_if { plugin_enabled?(new_resource.plugin) }
   end
 end

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -79,31 +79,29 @@ def user_has_permissions?(name, vhost, perm_list = nil) # rubocop:disable all
 end
 
 action :add do
-  unless user_exists?(new_resource.user)
-    Chef::Application.fatal!('rabbitmq_user with action :add requires a non-nil/empty password.') if new_resource.password.nil? || new_resource.password.empty?
+  Chef::Application.fatal!('rabbitmq_user with action :add requires a non-nil/empty password.') if new_resource.password.nil? || new_resource.password.empty?
 
-    # To escape single quotes in a shell, you have to close the surrounding single quotes, add
-    # in an escaped single quote, and then re-open the original single quotes.
-    # Since this string is interpolated once by ruby, and then a second time by the shell, we need
-    # to escape the escape character ('\') twice.  This is why the following is such a mess
-    # of leaning toothpicks:
-    new_password = new_resource.password.gsub("'", "'\\\\''")
-    cmd = "rabbitmqctl add_user #{new_resource.user} '#{new_password}'"
-    execute "rabbitmqctl add_user #{new_resource.user}" do # ~FC009
-      sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
-      command cmd
-      Chef::Log.info "Adding RabbitMQ user '#{new_resource.user}'."
-    end
+  # To escape single quotes in a shell, you have to close the surrounding single quotes, add
+  # in an escaped single quote, and then re-open the original single quotes.
+  # Since this string is interpolated once by ruby, and then a second time by the shell, we need
+  # to escape the escape character ('\') twice.  This is why the following is such a mess
+  # of leaning toothpicks:
+  new_password = new_resource.password.gsub("'", "'\\\\''")
+  cmd = "rabbitmqctl add_user #{new_resource.user} '#{new_password}'"
+  execute "rabbitmqctl add_user #{new_resource.user}" do # ~FC009
+    sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
+    command cmd
+    Chef::Log.info "Adding RabbitMQ user '#{new_resource.user}'."
+    not_if { user_exists?(new_resource.user) }
   end
 end
 
 action :delete do
-  if user_exists?(new_resource.user)
-    cmd = "rabbitmqctl delete_user #{new_resource.user}"
-    execute cmd do
-      Chef::Log.debug "rabbitmq_user_delete: #{cmd}"
-      Chef::Log.info "Deleting RabbitMQ user '#{new_resource.user}'."
-    end
+  cmd = "rabbitmqctl delete_user"
+  execute "cmd #{new_resource.user}" do
+    Chef::Log.debug "rabbitmq_user_delete: #{cmd} #{new_resource.user}"
+    Chef::Log.info "Deleting RabbitMQ user '#{new_resource.user}'."
+    not_if { user_exists?(new_resource.user) }
   end
 end
 

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -97,7 +97,7 @@ action :add do
 end
 
 action :delete do
-  cmd = "rabbitmqctl delete_user"
+  cmd = 'rabbitmqctl delete_user'
   execute "#{cmd} #{new_resource.user}" do
     Chef::Log.debug "rabbitmq_user_delete: #{cmd} #{new_resource.user}"
     Chef::Log.info "Deleting RabbitMQ user '#{new_resource.user}'."

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -98,10 +98,10 @@ end
 
 action :delete do
   cmd = "rabbitmqctl delete_user"
-  execute "cmd #{new_resource.user}" do
+  execute "#{cmd} #{new_resource.user}" do
     Chef::Log.debug "rabbitmq_user_delete: #{cmd} #{new_resource.user}"
     Chef::Log.info "Deleting RabbitMQ user '#{new_resource.user}'."
-    not_if { user_exists?(new_resource.user) }
+    only_if { user_exists?(new_resource.user) }
   end
 end
 

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -25,12 +25,11 @@ cluster_nodes = node['rabbitmq']['clustering']['cluster_nodes']
 cluster_nodes = cluster_nodes.to_json
 
 if node['rabbitmq']['cluster']
-  # Manual clustering
-  unless node['rabbitmq']['clustering']['use_auto_clustering']
-    # Join in cluster
-    rabbitmq_cluster cluster_nodes do
-      action :join
-    end
+  # Manual clustering 
+  # Join in cluster
+  rabbitmq_cluster cluster_nodes do
+    action :join
+    not_if { node['rabbitmq']['clustering']['use_auto_clustering'] }
   end
   # Set cluster name : It will be skipped once same cluster name has been set in the cluster.
   rabbitmq_cluster cluster_nodes do

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -25,7 +25,7 @@ cluster_nodes = node['rabbitmq']['clustering']['cluster_nodes']
 cluster_nodes = cluster_nodes.to_json
 
 if node['rabbitmq']['cluster']
-  # Manual clustering 
+  # Manual clustering
   # Join in cluster
   rabbitmq_cluster cluster_nodes do
     action :join

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -146,13 +146,12 @@ when 'smartos'
 
 end
 
-if node['rabbitmq']['logdir']
-  directory node['rabbitmq']['logdir'] do
-    owner 'rabbitmq'
-    group 'rabbitmq'
-    mode '775'
-    recursive true
-  end
+directory node['rabbitmq']['logdir'] do
+  owner 'rabbitmq'
+  group 'rabbitmq'
+  mode '775'
+  recursive true
+  only_if { node['rabbitmq']['logdir'] }
 end
 
 directory node['rabbitmq']['mnesiadir'] do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -146,12 +146,13 @@ when 'smartos'
 
 end
 
-directory "#{node['rabbitmq']['logdir']}" do
-  owner 'rabbitmq'
-  group 'rabbitmq'
-  mode '775'
-  recursive true
-  only_if { node['rabbitmq']['logdir'] }
+if node['rabbitmq']['logdir'] 
+  directory node['rabbitmq']['logdir'] do
+    owner 'rabbitmq'
+    group 'rabbitmq'
+    mode '775'
+    recursive true
+  end
 end
 
 directory node['rabbitmq']['mnesiadir'] do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -146,7 +146,7 @@ when 'smartos'
 
 end
 
-if node['rabbitmq']['logdir'] 
+if node['rabbitmq']['logdir']
   directory node['rabbitmq']['logdir'] do
     owner 'rabbitmq'
     group 'rabbitmq'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -146,7 +146,7 @@ when 'smartos'
 
 end
 
-directory node['rabbitmq']['logdir'] do
+directory "#{node['rabbitmq']['logdir']}" do
   owner 'rabbitmq'
   group 'rabbitmq'
   mode '775'


### PR DESCRIPTION
## Before

```
foodcritic -B rabbitmq
FC023: Prefer conditional attributes: rabbitmq/providers/plugin.rb:35
FC023: Prefer conditional attributes: rabbitmq/providers/plugin.rb:46
FC023: Prefer conditional attributes: rabbitmq/recipes/cluster.rb:29
FC023: Prefer conditional attributes: rabbitmq/recipes/default.rb:149
```
## Now

```
foodcritic -B rabbitmq
FC023: Prefer conditional attributes: rabbitmq/recipes/default.rb:149
```

I note on the last, I side with [Jay Feldblum](https://github.com/yfeldblum) regarding http://www.foodcritic.io/#FC023

Specifying: `default['rabbitmq']['logdir']` for all `node['platform_family']` based on [RabbitMQ File Locations](https://www.rabbitmq.com/relocate.html) seems excessive.

Cheers.
