### PR TITLE
Cluster join never happens for manual clustering

### DIFF
--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -209,21 +209,21 @@ action :join do
     Chef::Log.warn("[rabbitmq_cluster] Node is already member of your desired cluster #{current_cluster_name(var_cluster_status)}. Joining cluster will be skipped.")
   else
     if joined_cluster?(var_node_name, var_cluster_status) && current_cluster_name(var_cluster_status) != var_cluster_name
-       unless var_cluster_name.nil?
-          Chef::Log.warn("[rabbitmq_cluster] Node is already member of #{current_cluster_name(var_cluster_status)}. Rejoining the desired cluster.")
-       end
-    else
-       run_rabbitmqctl('stop_app')
-
-       # Catch JoinError so that we can leave Rabbit started, if possible
-       begin
-          join_cluster(var_node_name_to_join, var_node_type)
-       rescue JoinError => exc
-          Chef::Application.fatal!("[rabbitmq_cluster] #{exc.message}")
-       ensure
-          run_rabbitmqctl('start_app')
-       end
+      unless var_cluster_name.nil?
+        Chef::Log.warn("[rabbitmq_cluster] Node is already member of #{current_cluster_name(var_cluster_status)}. Rejoining the desired cluster.")
+      end
     end
+    run_rabbitmqctl('stop_app')
+
+    # Catch JoinError so that we can leave Rabbit started, if possible
+    begin
+      join_cluster(var_node_name_to_join, var_node_type)
+    rescue JoinError => exc
+      Chef::Application.fatal!("[rabbitmq_cluster] #{exc.message}")
+    ensure
+      run_rabbitmqctl('start_app')
+    end
+
     Chef::Log.info("[rabbitmq_cluster] Node #{var_node_name} joined in #{var_node_name_to_join} with type #{var_node_type}")
     Chef::Log.info(cluster_status)
   end

--- a/recipes/cluster.rb
+++ b/recipes/cluster.rb
@@ -28,6 +28,7 @@ cluster_nodes = cluster_nodes.to_json
 unless node['rabbitmq']['clustering']['use_auto_clustering']
   # Join in cluster
   rabbitmq_cluster cluster_nodes do
+    cluster_name node['rabbitmq']['clustering']['cluster_name']
     action :join
   end
 end


### PR DESCRIPTION
When using manual clustering in this cookbook, rabbitmq(e.g. rabbit1-ubuntu-1404) starts as a member of a single node cluster named as its own hostname. 
And the current join action will never happen by just skipping with the warning message below.

> [rabbitmq_cluster] Node is already member of rabbit@rabbit1-ubuntu-1404. Joining cluster will be skipped.

This is because the current join action process doesn't consider the current cluster name and only checks if the node is a part of whatever cluster or not.

This PR is to check if the node is a part of the desired cluster defined through the attribute ( node['rabbitmq']['clustering']['cluster_name'] ) so that the join action will happen if the node is a part of the wrong/(in my case, default=hostname) cluster.