### PR TITLE
apply_to parameter missing

### DIFF
--- a/recipes/policy_management.rb
+++ b/recipes/policy_management.rb
@@ -27,6 +27,7 @@ node['rabbitmq']['policies'].each do |name, policy|
     params policy['params']
     priority policy['priority']
     vhost policy['vhost']
+    apply_to policy['apply_to']
     action :set
     notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
   end


### PR DESCRIPTION
The policy provider accepts the apply_to parameter but the recipe is not passing it in. I've modified and tested the change in production and it works correctly. Screenshot attached.

![screen shot 2016-06-16 at 9 12 27 am](https://cloud.githubusercontent.com/assets/9114842/16117951/c38c53e4-33a2-11e6-8eab-2fa94fbd532e.png)
