### PR TITLE
Add support for non ssl management port

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -104,6 +104,9 @@ default['rabbitmq']['ssl_ciphers'] = nil
 default['rabbitmq']['web_console_ssl'] = false
 default['rabbitmq']['web_console_ssl_port'] = 15_671
 
+# Change non SSL web console listen port
+default['rabbitmq']['web_console_port'] = 15672
+
 # tcp listen options
 default['rabbitmq']['tcp_listen'] = true
 default['rabbitmq']['tcp_listen_packet'] = 'raw'

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -18,6 +18,12 @@
                     ]}
               ]}
   ]},
+<% else %>
+  {rabbitmq_management, [
+    {listener, [
+                {port, <%= node['rabbitmq']['web_console_port'] %>}
+    ]}
+  ]},
 <% end %>
 <% if node['rabbitmq']['ssl'] && @ssl_versions -%>
   {ssl, [{versions, [<%= @ssl_versions %>]}]},


### PR DESCRIPTION
This commit adds support for changing the management port of the
RabbitMQ management web interface.