### PR TITLE
Update readme to require Chef 12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # rabbitmq Cookbook
 
 [![Build Status](https://travis-ci.org/rabbitmq/chef-cookbook.svg?branch=master)](https://travis-ci.org/rabbitmq/chef-cookbook)
+[![Cookbook Version](https://img.shields.io/cookbook/v/rabbitmq.svg)](https://supermarket.chef.io/cookbooks/rabbitmq)
 
-This is a cookbook for managing RabbitMQ with Chef. It is intended for RabbitMQ 2.6.1 or later releases. With Chef we have adopted support >= 11.14.0 for chef-client, and leaning heavily on chef-client 12 and above.
+This is a cookbook for managing RabbitMQ with Chef. It is intended for RabbitMQ 2.6.1 or later releases and Chef 12.1 and later.
 
 **NOTE**: This cookbook is still maintained by @jjasghar, please ping him on PRs or Issues you may find.
 


### PR DESCRIPTION
The issues_url and source_url metadata break Chef 11 support so this cookbook already requires Chef 12+