### PR TITLE
Provision 3.6.8 by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # Latest RabbitMQ.com version to install
-default['rabbitmq']['version'] = '3.6.1'
+default['rabbitmq']['version'] = '3.6.8'
 # The distro versions may be more stable and have back-ported patches
 default['rabbitmq']['use_distro_version'] = false
 # Allow the distro version to be optionally pinned like the rabbitmq.com version


### PR DESCRIPTION
Inspired by #414.

@jjasghar any objections? any other places where we need to change that default that I may have missed? (e.g. around tests)