### PR TITLE
Policies Attribute Fix

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -151,7 +151,7 @@ default['rabbitmq']['heartbeat'] = 60
 
 # per default all policies and disabled policies are empty but need to be
 # defined
-default['rabbitmq']['policies'] = []
+default['rabbitmq']['policies'] = {}
 default['rabbitmq']['disabled_policies'] = []
 
 # Example HA policies


### PR DESCRIPTION
Policies is a hash

https://github.com/rabbitmq/chef-cookbook/blob/master/recipes/policy_management.rb#L24

This causes an error if you define something like this in a wrapper, without making it an override.
```ruby
default['rabbitmq']['policies']['ha-all']['pattern'] = '^(?!amq\\.).*'
```