### PR TITLE
Fix Case Statement for RHEL

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,11 +11,10 @@ default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabb
 
 case node['platform_family']
 when 'rhel', 'fedora'
-  case node['platform_version']
-  when <= '6'
-    default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.el6.noarch.rpm"
-  when > '6'
+  if node['platform_version'].to_i > 6
     default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.el7.noarch.rpm"
+  else
+    default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.el6.noarch.rpm"
   end
 when 'suse'
   default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.suse.noarch.rpm"


### PR DESCRIPTION
When can't have any logic in it, it is purely a === operator

```
==> rabbitmq-1: SyntaxError
==> rabbitmq-1: -----------
==> rabbitmq-1: /var/chef/cache/cookbooks/rabbitmq/attributes/default.rb:15: syntax error, unexpected <=
==> rabbitmq-1:   when <= '6'
==> rabbitmq-1:          ^
==> rabbitmq-1: /var/chef/cache/cookbooks/rabbitmq/attributes/default.rb:17: syntax error, unexpected '>'
==> rabbitmq-1:   when > '6'
==> rabbitmq-1:         ^
==> rabbitmq-1: /var/chef/cache/cookbooks/rabbitmq/attributes/default.rb:20: syntax error, unexpected keyword_when, expecting end-of-input
==> rabbitmq-1: when 'suse'
```
