### PR TITLE
reassign variable with frozen string  instead of appending to it

### DIFF
--- a/providers/parameter.rb
+++ b/providers/parameter.rb
@@ -27,8 +27,8 @@ use_inline_resources
 
 def parameter_exists?(vhost, name)
   cmd = 'rabbitmqctl list_parameters'
-  cmd << " -p #{Shellwords.escape vhost}" unless vhost.nil?
-  cmd << " |grep '#{name}\\b'"
+  cmd += " -p #{Shellwords.escape vhost}" unless vhost.nil?
+  cmd += " |grep '#{name}\\b'"
 
   cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   cmd.run_command
@@ -43,13 +43,13 @@ end
 action :set do
   unless parameter_exists?(new_resource.vhost, new_resource.parameter)
     cmd = 'rabbitmqctl set_parameter'
-    cmd << " -p #{new_resource.vhost}" unless new_resource.vhost.nil?
-    cmd << " #{new_resource.component}"
-    cmd << " #{new_resource.parameter}"
+    cmd += " -p #{new_resource.vhost}" unless new_resource.vhost.nil?
+    cmd += " #{new_resource.component}"
+    cmd += " #{new_resource.parameter}"
 
-    cmd << " '"
-    cmd << JSON.dump(new_resource.params)
-    cmd << "'"
+    cmd += " '"
+    cmd += JSON.dump(new_resource.params)
+    cmd += "'"
 
     parameter = "#{new_resource.component} #{new_resource.parameter}"
 

--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -27,8 +27,8 @@ use_inline_resources
 
 def policy_exists?(vhost, name)
   cmd = 'rabbitmqctl list_policies'
-  cmd << " -p #{Shellwords.escape vhost}" unless vhost.nil?
-  cmd << " |grep '#{name}\\b'"
+  cmd += " -p #{Shellwords.escape vhost}" unless vhost.nil?
+  cmd += " |grep '#{name}\\b'"
 
   cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
   cmd.run_command
@@ -43,17 +43,17 @@ end
 action :set do
   unless policy_exists?(new_resource.vhost, new_resource.policy)
     cmd = 'rabbitmqctl set_policy'
-    cmd << " -p #{new_resource.vhost}" unless new_resource.vhost.nil?
-    cmd << " --apply-to #{new_resource.apply_to}" if new_resource.apply_to
-    cmd << " #{new_resource.policy}"
-    cmd << " \"#{new_resource.pattern}\""
-    cmd << " '{"
+    cmd += " -p #{new_resource.vhost}" unless new_resource.vhost.nil?
+    cmd += " --apply-to #{new_resource.apply_to}" if new_resource.apply_to
+    cmd += " #{new_resource.policy}"
+    cmd += " \"#{new_resource.pattern}\""
+    cmd += " '{"
 
     first_param = true
     new_resource.params.each do |key, value|
-      cmd << ',' unless first_param
+      cmd += ',' unless first_param
 
-      cmd << if value.is_a? String
+      cmd += if value.is_a? String
                "\"#{key}\":\"#{value}\""
              else
                "\"#{key}\":#{value}"
@@ -61,11 +61,11 @@ action :set do
       first_param = false
     end
 
-    cmd << "}'"
+    cmd += "}'"
     if node['rabbitmq']['version'] >= '3.2.0'
-      cmd << " --priority #{new_resource.priority}" if new_resource.priority
+      cmd += " --priority #{new_resource.priority}" if new_resource.priority
     else
-      cmd << " #{new_resource.priority}" if new_resource.priority # rubocop:disable all
+      cmd += " #{new_resource.priority}" if new_resource.priority # rubocop:disable all
     end
 
     execute "set_policy #{new_resource.policy}" do
@@ -81,7 +81,7 @@ end
 action :clear do
   if policy_exists?(new_resource.vhost, new_resource.policy)
     cmd = "rabbitmqctl clear_policy #{new_resource.policy}"
-    cmd << " -p #{new_resource.vhost}" unless new_resource.vhost.nil?
+    cmd += " -p #{new_resource.vhost}" unless new_resource.vhost.nil?
     execute "clear_policy #{new_resource.policy}" do
       command cmd
       environment shell_environment


### PR DESCRIPTION
This change allows us to change string variables without actually mutating them.
This allows these files to be compatible with ruby 3.0 in the future.

Ruby 3.0 will have frozen strings, which prevents the `<<` operator from working, because it attempts to mutate a frozen string.

Using the `+=` operator reassigns the original variable instead of mutating it.

Fixes #422 