### PR TITLE
Rename params property to parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ sets or clears a rabbitmq policy.
 ```ruby
 rabbitmq_policy "ha-all" do
   pattern "^(?!amq\\.).*"
-  params ({"ha-mode"=>"all"})
+  parameters ({"ha-mode"=>"all"})
   priority 1
   action :set
 end

--- a/providers/parameter.rb
+++ b/providers/parameter.rb
@@ -48,7 +48,7 @@ action :set do
     cmd += " #{new_resource.parameter}"
 
     cmd += " '"
-    cmd += JSON.dump(new_resource.params)
+    cmd += JSON.dump(new_resource.parameters)
     cmd += "'"
 
     parameter = "#{new_resource.component} #{new_resource.parameter}"

--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -49,7 +49,7 @@ action :set do
   cmd += " '{"
 
   first_param = true
-  new_resource.params.each do |key, value|
+  new_resource.parameters.each do |key, value|
     cmd += ',' unless first_param
 
     cmd += if value.is_a? String

--- a/recipes/policy_management.rb
+++ b/recipes/policy_management.rb
@@ -25,7 +25,7 @@ include_recipe 'rabbitmq::default'
 node['rabbitmq']['policies'].each do |name, policy|
   rabbitmq_policy name do
     pattern policy['pattern']
-    params policy['params']
+    parameters policy['params']
     priority policy['priority']
     vhost policy['vhost']
     apply_to policy['apply_to']

--- a/resources/parameter.rb
+++ b/resources/parameter.rb
@@ -25,4 +25,4 @@ default_action :set
 attribute :parameter, :kind_of => String, :name_attribute => true
 attribute :component, :kind_of => String
 attribute :vhost, :kind_of => String
-attribute :params, :kind_of => [Hash, Array], :default => {}
+attribute :parameters, :kind_of => [Hash, Array], :default => {}

--- a/resources/policy.rb
+++ b/resources/policy.rb
@@ -24,7 +24,7 @@ default_action :set
 
 attribute :policy, :kind_of => String, :name_attribute => true
 attribute :pattern, :kind_of => String
-attribute :params, :kind_of => Hash
+attribute :parameters, :kind_of => Hash
 attribute :priority, :kind_of => Integer
 attribute :vhost, :kind_of => String
 attribute :apply_to, :kind_of => String, :equal_to => %w(all queues exchanges)

--- a/test/cookbooks/rabbitmq_test/recipes/lwrps.rb
+++ b/test/cookbooks/rabbitmq_test/recipes/lwrps.rb
@@ -56,7 +56,7 @@ end
 
 rabbitmq_policy 'rabbitmq_cluster' do
   pattern 'cluster.*'
-  params 'ha-mode' => 'all', 'ha-sync-mode' => 'automatic'
+  parameters 'ha-mode' => 'all', 'ha-sync-mode' => 'automatic'
   apply_to 'queues'
   action :set
 end
@@ -68,5 +68,5 @@ rabbitmq_vhost '/sensu'
 rabbitmq_parameter 'sensu-dc-1' do
   vhost '/sensu'
   component 'federation-upstream'
-  params 'uri' => 'amqp://dc-cluster-node'
+  parameters 'uri' => 'amqp://dc-cluster-node'
 end


### PR DESCRIPTION
This cleans up the resource property errors.

Note: This is a breaking change

```
================================================================================
Recipe Compile Error in /opt/kitchen/cache/cookbooks/rabbitmq/resources/parameter.rb
================================================================================
ArgumentError
-------------
Property `params` of resource `rabbitmq_parameter` overwrites an existing method.
Cookbook Trace:
---------------
  /opt/kitchen/cache/cookbooks/rabbitmq/resources/parameter.rb:28:in `class_from_file'
Relevant File Content:
----------------------
/opt/kitchen/cache/cookbooks/rabbitmq/resources/parameter.rb:
 21:
 22:  actions :set, :clear, :list
 23:  default_action :set
 24:
 25:  attribute :parameter, :kind_of => String, :name_attribute => true
 26:  attribute :component, :kind_of => String
 27:  attribute :vhost, :kind_of => String
 28>> attribute :params, :kind_of => [Hash, Array], :default => {}
 29:
Platform:
---------
x86_64-linux
```