### PR TITLE
Update kitchen dokken

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -47,6 +47,13 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install lsb-release procps -y
+  - name: debian-8
+    driver:
+      image: debian:8
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install lsb-release procps -y
 
 
 suites:

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -32,10 +32,14 @@ platforms:
     driver:
       image: ubuntu-upstart:14.04
       pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
   - name: ubuntu-16.04
     driver:
       image: ubuntu:16.04
       pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
   - name: debian-7
     driver:
       image: debian:7

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ services: docker
 
 env:
   matrix:
+  - INSTANCE=centos-6
   - INSTANCE=centos-7
+  - INSTANCE=debian-7
+  - INSTANCE=debian-8
   - INSTANCE=ubuntu-1404
   - INSTANCE=ubuntu-1604
 


### PR DESCRIPTION
- Ubuntu needs apt-get update before running tests so that it has the newest package version metadata
- Add debian-8 testing

Fixes the ubuntu test failure seen in https://github.com/rabbitmq/chef-cookbook/pull/427

Note: dokken tests will fail until https://github.com/rabbitmq/chef-cookbook/pull/427 is merged in