### PR TITLE
Update to default.rb library to handle frozen strings

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -34,10 +34,10 @@ module Opscode
       # theoretically opens the door for arbitrary kernel_app parameters to be
       # declared.
       kernel.select { |_k, v| !v.nil? }.each_pair do |param, val|
-        rendered << "{#{param}, #{val}}"
+        rendered << "    {#{param}, #{val}}"
       end
 
-      rendered.each { |r| r.prepend('    ') }.join(",\n")
+      rendered.each { |r| r }.join(",\n")
     end
 
     def format_ssl_versions


### PR DESCRIPTION
When running under Chef client 13, Chef issues an error on the prepend method for the string because the strings are frozen objects.  By moving the whitespace characters to the original array creation, we can do a simple non-destructive join, which solves the issue of not being allowed to change a frozen string in chef.