### PR TITLE
closes #432

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,11 @@ rabbitmq_cluster '[{"name":"rabbit@rabbit1","type":"disc"},{"name":"rabbit@rabbi
 end
 ```
 
+#### Removing nodes from cluster
+
+This cookbook provides the primitives to remove a node from a cluster via helper functions but do not include these in any recipes. This is something that is potentially very dangerous and different deployments will have different needs and IF you decide you need this it should be implemented in your wrapper with EXTREME caution. There are 2 helper methods for 2 different scenario:
+- removing self from cluster. This should likely only be considered for machines on a normal decommission. This is accomplished by using the helper fucntion `reset_current_node`.
+- removing another node from cluster. This should only be done once you are sure the machine is gone and won't come back. This can be accomplished via `remove_remote_node_from_cluster`.
 
 ## Limitations
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,22 @@
+module RabbitMQCookbook
+  module Helpers
+    require 'mixlib/shellout'
+
+    def reset_current_node
+      # stop rmq
+      stop_rmq = Mixlib::ShellOut.new('rabbitmqctl stop_app')
+      stop_rmq.run_command
+      stop_rmq.error!
+      # remove self from cluster
+      reset_rmq = Mixlib::ShellOut.new('rabbitmqctl reset')
+      reset_rmq.run_command
+      reset_rmq.error!
+    end
+
+    def remove_remote_node_from_cluster(rmq_node)
+      remove_from_cluster = Mixlib::ShellOut.new("rabbitmqctl forget_cluster_node #{rmq_node}")
+      remove_from_cluster.run_command
+      remove_from_cluster.error!
+    end
+  end
+end


### PR DESCRIPTION
This adds some helper functions to allow a wrapper cookbook to implement removing a node from a cluster in 2 scenarios:
- removing self from cluster (helpful for normal decommission)
- removing any node from cluster (helpful for abruptly terminated machines)

These both should not be actually consumed in this cookbook and simply be provided for wrappers to use as they see fit. This should be implemented only after careful thought, design, testing, etc.