### PR TITLE
mount cgroup in docker, even when privileged

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -2,7 +2,9 @@ driver:
   name: dokken
   chef_version: latest
   privileged: true # because Docker and SystemD/Upstart
-
+  volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup
+    
 transport:
   name: dokken
 


### PR DESCRIPTION
A possible workaround for #435 