### PR TITLE
The rabbitmq config needs to have the exact same name as the config attribute as this is used to source from rabbitmq-env

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,7 +51,7 @@ default['rabbitmq']['manage_service'] = true
 # http://www.rabbitmq.com/configure.html#define-environment-variables
 # "The .config extension is automatically appended by the Erlang runtime."
 default['rabbitmq']['config_root'] = '/etc/rabbitmq'
-default['rabbitmq']['config'] = "#{node['rabbitmq']['config_root']}/rabbitmq"
+default['rabbitmq']['config'] = "#{node['rabbitmq']['config_root']}/rabbitmq.config"
 default['rabbitmq']['erlang_cookie_path'] = '/var/lib/rabbitmq/.erlang.cookie'
 default['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
 # override this if you wish to provide `rabbitmq.config.erb` in your own wrapper cookbook

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -186,7 +186,7 @@ template "#{node['rabbitmq']['config_root']}/rabbitmq-env.conf" do
   notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
 end
 
-template "#{node['rabbitmq']['config']}.config" do
+template "#{node['rabbitmq']['config']}" do
   sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
   source 'rabbitmq.config.erb'
   cookbook node['rabbitmq']['config_template_cookbook']


### PR DESCRIPTION
This will fix the config include from `templates/default/rabbitmq-env.conf.erb`

`<% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= node['rabbitmq']['config'] %><% end %>`