### PR TITLE
Do not restart RabbitMQ for Policy Change

### DIFF
--- a/recipes/policy_management.rb
+++ b/recipes/policy_management.rb
@@ -30,13 +30,11 @@ node['rabbitmq']['policies'].each do |name, policy|
     vhost policy['vhost']
     apply_to policy['apply_to']
     action :set
-    notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
   end
 end
 
 node['rabbitmq']['disabled_policies'].each do |policy|
   rabbitmq_policy policy do
     action :clear
-    notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
   end
 end


### PR DESCRIPTION
Addresses https://github.com/rabbitmq/chef-cookbook/issues/441

We don't have to restart RabbitMQ to apply policies.

The changes in https://github.com/rabbitmq/chef-cookbook/pull/425 will cause these notifications to fire on every Chef run.

Straight from https://www.rabbitmq.com/parameters.html
```
Policies can change at any time. 
When a policy definition is updated, its effect on matching exchanges and queues will be reapplied.
Usually it happens instantaneously but for very busy queues can take a bit of time (say, a few seconds).
```