### PR TITLE
Remediate RabbitMQ reset failures

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -245,6 +245,8 @@ if node['rabbitmq']['clustering']['enable'] && (node['rabbitmq']['erlang_cookie'
   execute 'reset-node' do
     command 'rabbitmqctl stop_app && rabbitmqctl reset && rabbitmqctl start_app'
     action :nothing
+    retries 12
+    retry_delay 5
   end
 end
 


### PR DESCRIPTION
We were getting intermittent failures after the erlang cookie was changed.
They looked like this:

```
Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '69'
---- Begin output of rabbitmqctl stop_app && rabbitmqctl reset && rabbitmqctl start_app ----
STDOUT: Stopping rabbit application on node '3f49a593-39c1-4954-9c38-f3e763cb4ee3@ip-10-72-81-113' ...
STDERR: Error: unable to connect to node '3f49a593-39c1-4954-9c38-f3e763cb4ee3@ip-10-72-81-113': nodedown

DIAGNOSTICS
===========

attempted to contact: ['3f49a593-39c1-4954-9c38-f3e763cb4ee3@ip-10-72-81-113']

3f49a593-39c1-4954-9c38-f3e763cb4ee3@ip-10-72-81-113:
  * connected to epmd (port 4369) on ip-10-72-81-113
  * epmd reports: node '3f49a593-39c1-4954-9c38-f3e763cb4ee3' not running at all
                  no other nodes on ip-10-72-81-113
  * suggestion: start the node

current node details:
- node name: 'rabbitmq-cli-19@ip-10-72-81-113'
- home dir: /var/lib/rabbitmq
- cookie hash: WYSyTQI4sAl0fW/1IdQOyQ==
---- End output of rabbitmqctl stop_app && rabbitmqctl reset && rabbitmqctl start_app ----
Ran rabbitmqctl stop_app && rabbitmqctl reset && rabbitmqctl start_app returned
```

The Erlang VM was up but it had not had time to bring up the RabbitMQ app.
This patch adds some retries to the command to give the time needed.
Given that we only sometimes saw this error, a minute of retries
should be more than enough.

I did not add any tests because I am not sure how to test an intermittent failure.