### PR TITLE
Added support for Amazon platform family.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['versio
 default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
 
 case node['platform_family']
-when 'rhel', 'fedora'. 'amazon'
+when 'rhel', 'fedora', 'amazon'
   default['rabbitmq']['rpm_package'] = if node['platform_version'].to_i > 6
                                          "rabbitmq-server-#{node['rabbitmq']['version']}-1.el7.noarch.rpm"
                                        else

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['versio
 default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
 
 case node['platform_family']
-when 'rhel', 'fedora'
+when 'rhel', 'fedora'. 'amazon'
   default['rabbitmq']['rpm_package'] = if node['platform_version'].to_i > 6
                                          "rabbitmq-server-#{node['rabbitmq']['version']}-1.el7.noarch.rpm"
                                        else

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -110,7 +110,7 @@ when 'debian'
     end
   end
 
-when 'rhel', 'fedora'
+when 'rhel', 'fedora', 'amazon'
 
   # logrotate is a package dependency of rabbitmq-server
   package 'logrotate'


### PR DESCRIPTION
Amazon Linux now has it's own platform family defined by ohai. It is no longer categorized under rhel.