### PR TITLE
Request for adding retry to node start 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -196,6 +196,6 @@ default['rabbitmq']['disabled_policies'] = []
 default['rabbitmq']['conf'] = {}
 default['rabbitmq']['additional_rabbit_configs'] = {}
 
-# retry
-default['rabbitmq']['retry'] = 5
-default['rabbitmq']['retry_delay'] = 10
+# retry - Keeping defualts to chef service resource defualts 
+default['rabbitmq']['retry'] = 0
+default['rabbitmq']['retry_delay'] = 2

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -195,3 +195,7 @@ default['rabbitmq']['disabled_policies'] = []
 # conf
 default['rabbitmq']['conf'] = {}
 default['rabbitmq']['additional_rabbit_configs'] = {}
+
+# retry
+default['rabbitmq']['retry'] = 5
+default['rabbitmq']['retry_delay'] = 10

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -252,7 +252,7 @@ end
 
 if node['rabbitmq']['manage_service']
   service node['rabbitmq']['service_name'] do
-    retry node['rabbitmq']['retry']
+    retries node['rabbitmq']['retry']
     retry_delay node['rabbitmq']['retry_delay']
     action [:enable, :start]
     supports :status => true, :restart => true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -252,9 +252,9 @@ end
 
 if node['rabbitmq']['manage_service']
   service node['rabbitmq']['service_name'] do
-    action [:enable, :start]
     retry node['rabbitmq']['retry']
     retry_delay node['rabbitmq']['retry_delay']
+    action [:enable, :start]
     supports :status => true, :restart => true
     provider Chef::Provider::Service::Upstart if node['rabbitmq']['job_control'] == 'upstart'
     provider Chef::Provider::Service::Init if node['rabbitmq']['job_control'] == 'init'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -253,6 +253,8 @@ end
 if node['rabbitmq']['manage_service']
   service node['rabbitmq']['service_name'] do
     action [:enable, :start]
+    retry node['rabbitmq']['retry']
+    retry_delay node['rabbitmq']['retry_delay']
     supports :status => true, :restart => true
     provider Chef::Provider::Service::Upstart if node['rabbitmq']['job_control'] == 'upstart'
     provider Chef::Provider::Service::Init if node['rabbitmq']['job_control'] == 'init'


### PR DESCRIPTION
What we are noticing is that every time it get reconvered after the VM delete senario it failed once on second attempt it works so adding a retry to start the node, keeping values to defualt so no chang eofr anyone using cookbook but you can override defaults if you wanted to set to something else 