### PR TITLE
Make it possible to override base package URL location; switch default to GitHub

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,21 +7,11 @@ default['rabbitmq']['use_distro_version'] = false
 default['rabbitmq']['pin_distro_version'] = false
 
 # provide options to override download urls and package names
-default['rabbitmq']['deb_package'] = "rabbitmq-server_{VERSION}-1_all.deb"
-default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v{VERSION}/"
+default['rabbitmq']['deb_package'] = nil
+default['rabbitmq']['deb_package_url'] = nil
 
-case node['platform_family']
-when 'rhel', 'fedora'
-  default['rabbitmq']['rpm_package'] = if node['platform_version'].to_i > 6
-                                         "rabbitmq-server-{VERSION}-1.el7.noarch.rpm"
-                                       else
-                                         "rabbitmq-server-{VERSION}-1.el6.noarch.rpm"
-                                       end
-when 'suse'
-  default['rabbitmq']['rpm_package'] = "rabbitmq-server-{VERSION}-1.suse.noarch.rpm"
-end
-
-default['rabbitmq']['rpm_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v{VERSION}/"
+default['rabbitmq']['rpm_package'] = nil
+default['rabbitmq']['rpm_package_url'] = nil
 
 # RabbitMQ 3.6.8+ non-distro versions requires a modern Erlang which is neither available in
 # older distros via packages nor EPEL. rhel < 7, debian < 8

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,21 +7,21 @@ default['rabbitmq']['use_distro_version'] = false
 default['rabbitmq']['pin_distro_version'] = false
 
 # provide options to override download urls and package names
-default['rabbitmq']['deb_package'] = lazy { "rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb" }
-default['rabbitmq']['deb_package_url'] = lazy { "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/" }
+default['rabbitmq']['deb_package'] = "rabbitmq-server_{VERSION}-1_all.deb"
+default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v{VERSION}/"
 
 case node['platform_family']
 when 'rhel', 'fedora'
   default['rabbitmq']['rpm_package'] = if node['platform_version'].to_i > 6
-                                         lazy { "rabbitmq-server-#{node['rabbitmq']['version']}-1.el7.noarch.rpm" }
+                                         "rabbitmq-server-{VERSION}-1.el7.noarch.rpm"
                                        else
-                                         lazy { "rabbitmq-server-#{node['rabbitmq']['version']}-1.el6.noarch.rpm" }
+                                         "rabbitmq-server-{VERSION}-1.el6.noarch.rpm"
                                        end
 when 'suse'
-  default['rabbitmq']['rpm_package'] = lazy { "rabbitmq-server-#{node['rabbitmq']['version']}-1.suse.noarch.rpm" }
+  default['rabbitmq']['rpm_package'] = "rabbitmq-server-{VERSION}-1.suse.noarch.rpm"
 end
 
-default['rabbitmq']['rpm_package_url'] = lazy { "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/" }
+default['rabbitmq']['rpm_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v{VERSION}/"
 
 # RabbitMQ 3.6.8+ non-distro versions requires a modern Erlang which is neither available in
 # older distros via packages nor EPEL. rhel < 7, debian < 8
@@ -51,7 +51,7 @@ default['rabbitmq']['manage_service'] = true
 # http://www.rabbitmq.com/configure.html#define-environment-variables
 # "The .config extension is automatically appended by the Erlang runtime."
 default['rabbitmq']['config_root'] = '/etc/rabbitmq'
-default['rabbitmq']['config'] = lazy { "#{node['rabbitmq']['config_root']}/rabbitmq" }
+default['rabbitmq']['config'] = "#{node['rabbitmq']['config_root']}/rabbitmq"
 default['rabbitmq']['erlang_cookie_path'] = '/var/lib/rabbitmq/.erlang.cookie'
 default['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
 # override this if you wish to provide `rabbitmq.config.erb` in your own wrapper cookbook

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,21 +7,21 @@ default['rabbitmq']['use_distro_version'] = false
 default['rabbitmq']['pin_distro_version'] = false
 
 # provide options to override download urls and package names
-default['rabbitmq']['deb_package'] = "rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb"
-default['rabbitmq']['deb_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
+default['rabbitmq']['deb_package'] = lazy { "rabbitmq-server_#{node['rabbitmq']['version']}-1_all.deb" }
+default['rabbitmq']['deb_package_url'] = lazy { "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/" }
 
 case node['platform_family']
 when 'rhel', 'fedora'
   default['rabbitmq']['rpm_package'] = if node['platform_version'].to_i > 6
-                                         "rabbitmq-server-#{node['rabbitmq']['version']}-1.el7.noarch.rpm"
+                                         lazy { "rabbitmq-server-#{node['rabbitmq']['version']}-1.el7.noarch.rpm" }
                                        else
-                                         "rabbitmq-server-#{node['rabbitmq']['version']}-1.el6.noarch.rpm"
+                                         lazy { "rabbitmq-server-#{node['rabbitmq']['version']}-1.el6.noarch.rpm" }
                                        end
 when 'suse'
-  default['rabbitmq']['rpm_package'] = "rabbitmq-server-#{node['rabbitmq']['version']}-1.suse.noarch.rpm"
+  default['rabbitmq']['rpm_package'] = lazy { "rabbitmq-server-#{node['rabbitmq']['version']}-1.suse.noarch.rpm" }
 end
 
-default['rabbitmq']['rpm_package_url'] = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/"
+default['rabbitmq']['rpm_package_url'] = lazy { "https://www.rabbitmq.com/releases/rabbitmq-server/v#{node['rabbitmq']['version']}/" }
 
 # RabbitMQ 3.6.8+ non-distro versions requires a modern Erlang which is neither available in
 # older distros via packages nor EPEL. rhel < 7, debian < 8
@@ -51,7 +51,7 @@ default['rabbitmq']['manage_service'] = true
 # http://www.rabbitmq.com/configure.html#define-environment-variables
 # "The .config extension is automatically appended by the Erlang runtime."
 default['rabbitmq']['config_root'] = '/etc/rabbitmq'
-default['rabbitmq']['config'] = "#{node['rabbitmq']['config_root']}/rabbitmq"
+default['rabbitmq']['config'] = lazy { "#{node['rabbitmq']['config_root']}/rabbitmq" }
 default['rabbitmq']['erlang_cookie_path'] = '/var/lib/rabbitmq/.erlang.cookie'
 default['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
 # override this if you wish to provide `rabbitmq.config.erb` in your own wrapper cookbook

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,9 +28,9 @@ end
 include_recipe 'erlang'
 
 version = node['rabbitmq']['version']
-node.default['rabbitmq']['deb_package_url'].gsub! '{VERSION}', version
-node.default['rabbitmq']['rpm_package'].gsub! '{VERSION}', version
-node.default['rabbitmq']['rpm_package_url'].gsub! '{VERSION}', version
+%w(deb_package_url rpm_package rpm_package_url).each do |key|
+  node.default['rabbitmq'][key] = node['rabbitmq'][key].gsub('{VERSION}', version)
+end
 
 ## Install the package
 case node['platform_family']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,8 +29,9 @@ include_recipe 'erlang'
 
 version = node['rabbitmq']['version']
 
+default_package_url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v#{version}/"
+
 default_deb_package_name = "rabbitmq-server_#{version}-1_all.deb"
-default_deb_package_url = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{version}/"
 
 case node['platform_family']
 when 'rhel', 'fedora'
@@ -43,12 +44,10 @@ when 'suse'
   default_rpm_package = "rabbitmq-server-#{version}-1.suse.noarch.rpm"
 end
 
-default_rpm_package_url = "https://www.rabbitmq.com/releases/rabbitmq-server/v#{version}/"
-
 deb_package_name = node['rabbitmq']['deb_package'] || default_deb_package_name
-deb_package_url = node['rabbitmq']['deb_package_url'] || default_deb_package_url
+deb_package_url = node['rabbitmq']['deb_package_url'] || default_package_url
 rpm_package_name = node['rabbitmq']['rpm_package'] || default_rpm_package_name
-rpm_package_url = node['rabbitmq']['rpm_package_url'] || default_rpm_package_url
+rpm_package_url = node['rabbitmq']['rpm_package_url'] || default_package_url
 
 ## Install the package
 case node['platform_family']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,8 +28,9 @@ end
 include_recipe 'erlang'
 
 version = node['rabbitmq']['version']
+url_version = version.gsub('.', '_')
 
-default_package_url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/v#{version}/"
+default_package_url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v#{version}/"
 
 default_deb_package_name = "rabbitmq-server_#{version}-1_all.deb"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,8 @@ include_recipe 'erlang'
 
 version = node['rabbitmq']['version']
 %w(deb_package_url rpm_package rpm_package_url).each do |key|
-  node.default['rabbitmq'][key] = node['rabbitmq'][key].gsub('{VERSION}', version)
+  value = node['rabbitmq'][key]
+  node.default['rabbitmq'][key] = value.gsub('{VERSION}', version) if value
 end
 
 ## Install the package

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,11 @@ end
 
 include_recipe 'erlang'
 
+version = node['rabbitmq']['version']
+node.default['rabbitmq']['deb_package_url'].gsub! '{VERSION}', version
+node.default['rabbitmq']['rpm_package'].gsub! '{VERSION}', version
+node.default['rabbitmq']['rpm_package_url'].gsub! '{VERSION}', version
+
 ## Install the package
 case node['platform_family']
 when 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,7 @@ include_recipe 'erlang'
 version = node['rabbitmq']['version']
 url_version = version.gsub('.', '_')
 
-default_package_url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v#{version}/"
+default_package_url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v#{url_version}/"
 
 default_deb_package_name = "rabbitmq-server_#{version}-1_all.deb"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,12 @@ end
 include_recipe 'erlang'
 
 version = node['rabbitmq']['version']
-%w(deb_package_url rpm_package rpm_package_url).each do |key|
+%w(
+  deb_package
+  deb_package_url
+  rpm_package
+  rpm_package_url
+).each do |key|
   value = node['rabbitmq'][key]
   node.default['rabbitmq'][key] = value.gsub('{VERSION}', version) if value
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ end
 include_recipe 'erlang'
 
 version = node['rabbitmq']['version']
-url_version = version.gsub('.', '_')
+url_version = version.tr('.', '_')
 
 default_package_url = "https://github.com/rabbitmq/rabbitmq-server/releases/download/rabbitmq_v#{url_version}/"
 
@@ -42,7 +42,7 @@ when 'rhel', 'fedora'
                                "rabbitmq-server-#{version}-1.el6.noarch.rpm"
                              end
 when 'suse'
-  default_rpm_package = "rabbitmq-server-#{version}-1.suse.noarch.rpm"
+  default_rpm_package_name = "rabbitmq-server-#{version}-1.suse.noarch.rpm"
 end
 
 deb_package_name = node['rabbitmq']['deb_package'] || default_deb_package_name


### PR DESCRIPTION
Fixes #457, addresses [RabbitMQ core team request](https://groups.google.com/forum/#!topic/rabbitmq-users/9ASVq55wXnA) to switch to Bintray/GitHub/Package Cloud from rabbitmq.com.