### PR TITLE
Listen ip address configuration for management console.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -132,6 +132,9 @@ default['rabbitmq']['web_console_ssl_port'] = 15_671
 # Change non SSL web console listen port
 default['rabbitmq']['web_console_port'] = 15672
 
+# Add an ability to set web console listen ip.
+default['rabbitmq']['web_console_interface'] = nil
+
 # tcp listen options
 default['rabbitmq']['tcp_listen'] = true
 default['rabbitmq']['tcp_listen_packet'] = 'raw'

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -9,6 +9,9 @@
 <% if node['rabbitmq']['web_console_ssl'] -%>
   {rabbitmq_management, [
     {listener, [{port, <%= node['rabbitmq']['web_console_ssl_port'] %>},
+<% if node['rabbitmq']['web_console_interface'] -%>
+                {ip, "<%= node['rabbitmq']['web_console_interface'] %>"},
+<% end -%>
                 {ssl, true},
                 {ssl_opts, [{cacertfile,"<%= node['rabbitmq']['ssl_cacert'] %>"},
                     {certfile,"<%= node['rabbitmq']['ssl_cert'] %>"},
@@ -22,6 +25,9 @@
   {rabbitmq_management, [
     {listener, [
                 {port, <%= node['rabbitmq']['web_console_port'] %>}
+<% if node['rabbitmq']['web_console_interface'] -%>
+                ,{ip, "<%= node['rabbitmq']['web_console_interface'] %>"}
+<% end -%>
     ]}
   ]},
 <% end %>


### PR DESCRIPTION
Hello!

I've recently started using your cookbook for rabbitmq. In my case, all servers have public & private networking simultaneously, and I do not want RabbitMQ to listen on public network or `0.0.0.0` as it does by default.

In your cookbook, you already have attributes(and some hacks):

* `node['rabbitmq']['erl_networking_bind_address']`
* `node['rabbitmq']['erl_networking_bind_address']`
* `node['rabbitmq']['kernel']['inet_dist_use_interface']`

But nothing configures ip address for the management console. And I find it strange. I believe it is a pretty demanded option for many people.

e.g. [#442] is a similar issue, but addresses the problem even more globally.

Thank you very much!

P.S. About the tests. I do not see many tests for `rabbitmq.config` syntax and contents. I can cover my additions with some tests if you tell me so. Thank you again!