### PR TITLE
Mark the .erlang.cookie as sensitive.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -257,6 +257,7 @@ if node['rabbitmq']['clustering']['enable'] && (node['rabbitmq']['erlang_cookie'
     owner 'rabbitmq'
     group 'rabbitmq'
     mode 00400
+    sensitive true
     notifies :start, "service[#{node['rabbitmq']['service_name']}]", :immediately
     notifies :run, 'execute[reset-node]', :immediately
   end


### PR DESCRIPTION
This prevents the cookie from being logged in plain text.