### PR TITLE
Allow override of rabbitmq-env template

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -52,6 +52,8 @@ default['rabbitmq']['erlang_cookie_path'] = '/var/lib/rabbitmq/.erlang.cookie'
 default['rabbitmq']['erlang_cookie'] = 'AnyAlphaNumericStringWillDo'
 # override this if you wish to provide `rabbitmq.config.erb` in your own wrapper cookbook
 default['rabbitmq']['config_template_cookbook'] = 'rabbitmq'
+# override this if you wish to provide `rabbitmq-env.config.erb` in your own wrapper cookbook
+default['rabbitmq']['config-env_template_cookbook'] = 'rabbitmq'
 
 # rabbitmq.config defaults
 default['rabbitmq']['default_user'] = 'guest'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -212,6 +212,7 @@ end
 
 template "#{node['rabbitmq']['config_root']}/rabbitmq-env.conf" do
   source 'rabbitmq-env.conf.erb'
+  cookbook node['rabbitmq']['config-env_template_cookbook']
   owner 'root'
   group 'root'
   mode 00644


### PR DESCRIPTION
Using the same method provided for overriding the base config, allow overriding the env file too.