### PR TITLE
Ability to set interface to listen for SSL connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ node['rabbitmq']['ssl_cacert'] = '/path/to/cacert.pem'
 node['rabbitmq']['ssl_cert'] = '/path/to/cert.pem'
 node['rabbitmq']['ssl_key'] = '/path/to/key.pem'
 ```
+Listening for SSL connections may be limited specific interface by setting the following attribute:
+```
+node['rabbitmq']['ssl_listen_interface'] = nil
+```
 
 A full list of SSL attributes can be found in [attributes/default.rb](attributes/default.rb).
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,6 +113,7 @@ default['rabbitmq']['job_control'] = 'initd'
 # ssl
 default['rabbitmq']['ssl'] = false
 default['rabbitmq']['ssl_port'] = 5671
+default['rabbitmq']['ssl_listen_interface'] = nil
 default['rabbitmq']['ssl_cacert'] = '/path/to/cacert.pem'
 default['rabbitmq']['ssl_cert'] = '/path/to/cert.pem'
 default['rabbitmq']['ssl_key'] = '/path/to/key.pem'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -140,6 +140,19 @@ describe 'rabbitmq::default' do
         '{ciphers,["ECDHE-ECDSA-AES256-SHA384","ECDH-ECDSA-AES256-SHA384"]}')
     end
 
+    it 'does not set interface to listen for SSL by default' do
+      node.normal['rabbitmq']['ssl'] = true
+      expect(chef_run).not_to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
+        /{ssl_listeners, [5671]},/)
+    end
+
+    it 'is seting interface to listen for SSL if set' do
+      node.normal['rabbitmq']['ssl'] = true
+      node.normal['rabbitmq']['ssl_listen_interface'] = '0.0.0.0'
+      expect(chef_run).not_to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
+        /{ssl_listeners, [{"0.0.0.0", 5671}]},/)
+    end
+
     it 'should set additional rabbitmq config' do
       node.normal['rabbitmq']['additional_rabbit_configs'] = { 'foo' => 'bar' }
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('foo, bar')

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -42,7 +42,11 @@
     {cluster_partition_handling,<%= node['rabbitmq']['clustering']['cluster_partition_handling'] %>},
 <% end %>
 <% if node['rabbitmq']['ssl'] -%>
+    <% if node['rabbitmq']['ssl_listen_interface'] %>
+    {ssl_listeners, [{"<%= node['rabbitmq']['ssl_listen_interface'] %>", <%= node['rabbitmq']['ssl_port'] %>}]},
+    <% else %>
     {ssl_listeners, [<%= node['rabbitmq']['ssl_port'] %>]},
+    <% end %>
     {ssl_options, [{cacertfile,"<%= node['rabbitmq']['ssl_cacert'] %>"},
                     {certfile,"<%= node['rabbitmq']['ssl_cert'] %>"},
                     {keyfile,"<%= node['rabbitmq']['ssl_key'] %>"},


### PR DESCRIPTION
Attribute `node['rabbitmq']['ssl_listen_interface']` is set will define specific interface to bind.
May be filled with "0.0.0.0" (this will result in listening on IPv4 interfaces).
Will not affect existing config if left default (`nil`)