### PR TITLE
Add a config root resource, closes #351

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,7 +61,7 @@ rpm_package_url = node['rabbitmq']['rpm_package_url'] || default_package_url
 directory node['rabbitmq']['config_root'] do
   owner 'root'
   group 'root'
-  mode  '0440'
+  mode  '755'
   recursive true
   action :create
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,6 +57,15 @@ deb_package_url = node['rabbitmq']['deb_package_url'] || default_package_url
 rpm_package_name = node['rabbitmq']['rpm_package'] || default_rpm_package_name
 rpm_package_url = node['rabbitmq']['rpm_package_url'] || default_package_url
 
+# see rabbitmq/chef-cookbook#351
+directory node['rabbitmq']['config_root'] do
+  owner 'root'
+  group 'root'
+  mode  '0440'
+  recursive true
+  action :create
+end
+
 ## Install the package
 case node['platform_family']
 when 'debian'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -60,7 +60,16 @@ describe 'rabbitmq::default' do
     end
   end
 
-  it 'should create the directory /var/lib/rabbitmq/mnesia' do
+  it 'should create the config root directory' do
+    expect(chef_run).to create_directory('/etc/rabbitmq')
+      .with(
+        :user => 'root',
+        :group => 'root',
+        :mode => '0440'
+      )
+  end
+
+  it 'should create the node data directory' do
     expect(chef_run).to create_directory('/var/lib/rabbitmq/mnesia')
       .with(
         :user => 'rabbitmq',

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -65,7 +65,7 @@ describe 'rabbitmq::default' do
       .with(
         :user => 'root',
         :group => 'root',
-        :mode => '0440'
+        :mode => '755'
       )
   end
 


### PR DESCRIPTION
## Proposed Changes

This adds a directory resource that creates config root, as requested in #351.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #351)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #351.
