### PR TITLE
Make it possible to override TCP listener interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,22 @@ If you want to use the distro version, set the attribute `['rabbitmq']['use_dist
 The cluster recipe is now combined with the default and will now auto-cluster. Set the `['rabbitmq']['clustering']['enable']` attribute to `true`, `['rabbitmq']['clustering']['cluster_disk_nodes']` array of `node@host` strings that describe which you want to be disk nodes and then set an alphanumeric string for the `erlang_cookie`.
 
 To enable SSL turn `ssl` to `true` and set the paths to your cacert, cert and key files.
+
 ```ruby
 node['rabbitmq']['ssl'] = true
 node['rabbitmq']['ssl_cacert'] = '/path/to/cacert.pem'
 node['rabbitmq']['ssl_cert'] = '/path/to/cert.pem'
 node['rabbitmq']['ssl_key'] = '/path/to/key.pem'
 ```
-Listening for SSL connections may be limited specific interface by setting the following attribute:
+
+Listening for TCP connections may be limited to a specific interface by setting the following attribute:
+
+```
+node['rabbitmq']['tcp_listen_interface'] = nil
+```
+
+Listening for SSL connections may be limited to a specific interface by setting the following attribute:
+
 ```
 node['rabbitmq']['ssl_listen_interface'] = nil
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -149,6 +149,10 @@ default['rabbitmq']['web_console_interface'] = nil
 # TCP listener options, see
 # https://www.rabbitmq.com/networking.html for details.
 default['rabbitmq']['tcp_listen'] = true
+
+default['rabbitmq']['port'] = 5672
+default['rabbitmq']['tcp_listen_interface'] = nil
+
 default['rabbitmq']['tcp_listen_packet'] = 'raw'
 default['rabbitmq']['tcp_listen_reuseaddr'] = true
 default['rabbitmq']['tcp_listen_backlog'] = 128

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -169,15 +169,32 @@ describe 'rabbitmq::default' do
         /{ssl_listeners, [5671]},/)
     end
 
-    it 'is seting interface to listen for SSL if set' do
+    it 'is setting interface to listen for SSL if set' do
       node.normal['rabbitmq']['ssl'] = true
       node.normal['rabbitmq']['ssl_listen_interface'] = '0.0.0.0'
-      expect(chef_run).not_to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
-        /{ssl_listeners, [{"0.0.0.0", 5671}]},/)
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
+        /{ssl_listeners, \[{"0.0.0.0", 5671}\]},/)
+    end
+
+    it 'is setting port to listen for SSL if set' do
+      node.normal['rabbitmq']['ssl'] = true
+      node.normal['rabbitmq']['ssl_port'] = 5670
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
+        /{ssl_listeners, \[5670\]},/)
     end
   end
 
   describe 'TCP listener options' do
+    it 'allows interface to be overridden' do
+      node.normal['rabbitmq']['tcp_listen_interface'] = '192.168.1.10'
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{"192.168.1.10", 5672}')
+    end
+
+    it 'allows AMQP port to be overridden' do
+      node.normal['rabbitmq']['port'] = 5674
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('[5674]')
+    end
+
     it 'enables socket lingering by default' do
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{linger, {true,0}}')
     end

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -65,6 +65,13 @@
                     <% if node['rabbitmq']['ssl_honor_ecc_order'] -%>,{honor_ecc_order, <%= node['rabbitmq']['ssl_honor_ecc_order'] %>}<% end -%>
                     ]},
 <% end %>
+
+<% if node['rabbitmq']['tcp_listen_interface'] -%>
+{tcp_listeners, [{"<%= node['rabbitmq']['tcp_listen_interface'] %>", <%= node['rabbitmq']['port'] %>}]},
+<% else %>
+{tcp_listeners, [<%= node['rabbitmq']['port'] %>]},
+<% end -%>
+
 <% if node['rabbitmq']['tcp_listen'] -%>
     {tcp_listen_options, [{packet, <%= node['rabbitmq']['tcp_listen_packet'] %>},
                           {reuseaddr, <%= node['rabbitmq']['tcp_listen_reuseaddr'] %>},


### PR DESCRIPTION
## Proposed Changes

This PR makes it possible to override TCP listener interface.

The attributes used mimic those for TLS listeners. This
is not optimal because there is no way to set multiple
listeners, so this is something that is worth revisiting in 6.0.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #364)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #364.
