### PR TITLE
Make TCP buffer size configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -153,6 +153,7 @@ default['rabbitmq']['tcp_listen_exit_on_close'] = false
 default['rabbitmq']['tcp_listen_keepalive'] = false
 default['rabbitmq']['tcp_listen_linger'] = true
 default['rabbitmq']['tcp_listen_linger_timeout'] = 0
+default['rabbitmq']['tcp_listen_buffer'] = nil
 default['rabbitmq']['tcp_listen_sndbuf'] = nil
 default['rabbitmq']['tcp_listen_recbuf'] = nil
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -142,7 +142,8 @@ default['rabbitmq']['web_console_port'] = 15672
 # Add an ability to set web console listen ip.
 default['rabbitmq']['web_console_interface'] = nil
 
-# tcp listen options
+# TCP listener options, see
+# https://www.rabbitmq.com/networking.html for details.
 default['rabbitmq']['tcp_listen'] = true
 default['rabbitmq']['tcp_listen_packet'] = 'raw'
 default['rabbitmq']['tcp_listen_reuseaddr'] = true
@@ -152,6 +153,8 @@ default['rabbitmq']['tcp_listen_exit_on_close'] = false
 default['rabbitmq']['tcp_listen_keepalive'] = false
 default['rabbitmq']['tcp_listen_linger'] = true
 default['rabbitmq']['tcp_listen_linger_timeout'] = 0
+default['rabbitmq']['tcp_listen_sndbuf'] = nil
+default['rabbitmq']['tcp_listen_recbuf'] = nil
 
 # virtualhosts
 default['rabbitmq']['virtualhosts'] = []

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -174,6 +174,11 @@ describe 'rabbitmq::default' do
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{linger, {true,5}}')
     end
 
+    it 'supports explicit setting of TCP socket buffer' do
+      node.normal['rabbitmq']['tcp_listen_buffer'] = 16384
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{buffer, 16384}')
+    end
+
     it 'supports explicit setting of TCP socket send buffer' do
       node.normal['rabbitmq']['tcp_listen_sndbuf'] = 8192
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{sndbuf, 8192}')

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -159,21 +159,41 @@ describe 'rabbitmq::default' do
     end
   end
 
-  describe 'tcp_listen_linger' do
-    it 'default linger option' do
+  describe 'TCP listener options' do
+    it 'enables socket lingering by default' do
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{linger, {true,0}}')
     end
 
-    it 'false linger option' do
+    it 'supports disabling lingering' do
       node.normal['rabbitmq']['tcp_listen_linger'] = false
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{linger, {false,0}}')
     end
 
-    it 'linger option variable timeout' do
+    it 'supports setting lingering timeout' do
       node.normal['rabbitmq']['tcp_listen_linger_timeout'] = 5
       expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{linger, {true,5}}')
     end
+
+    it 'supports explicit setting of TCP socket send buffer' do
+      node.normal['rabbitmq']['tcp_listen_sndbuf'] = 8192
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{sndbuf, 8192}')
+    end
+
+    it 'supports explicit setting of TCP socket receive buffer' do
+      node.normal['rabbitmq']['tcp_listen_recbuf'] = 8192
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{recbuf, 8192}')
+    end
   end
+
+  describe 'credit flow' do
+    it 'can configure defaults' do
+      node.normal['rabbitmq']['credit_flow_defaults']['initial'] = 500
+      node.normal['rabbitmq']['credit_flow_defaults']['more_credit_after'] = 250
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('{credit_flow_default_credit, {500, 250}}')
+    end
+  end
+
+
 
   describe 'suse' do
     let(:runner) { ChefSpec::ServerRunner.new(SUSE_OPTS) }

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -70,6 +70,10 @@
                           {exit_on_close, <%= node['rabbitmq']['tcp_listen_exit_on_close'] %>},
                           {keepalive, <%= node['rabbitmq']['tcp_listen_keepalive'] %>},
 
+                          <% if node['rabbitmq']['tcp_listen_buffer'] -%>
+                          {buffer, <%= node['rabbitmq']['tcp_listen_buffer'] %>},
+                          <% end -%>
+
                           <% if node['rabbitmq']['tcp_listen_sndbuf'] -%>
                           {sndbuf, <%= node['rabbitmq']['tcp_listen_sndbuf'] %>},
                           <% end -%>

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -28,7 +28,7 @@
   {rabbitmq_management, [
 <% if node['rabbitmq']['management']['load_definitions'] %>
     {load_definitions, "<%= node['rabbitmq']['management']['definitions_file'] %>"},
-<% end -%>  
+<% end -%>
     {listener, [
                 {port, <%= node['rabbitmq']['web_console_port'] %>}
 <% if node['rabbitmq']['web_console_interface'] -%>
@@ -63,15 +63,24 @@
                     ]},
 <% end %>
 <% if node['rabbitmq']['tcp_listen'] -%>
-    {tcp_listen_options, [binary, {packet,<%= node['rabbitmq']['tcp_listen_packet'] %>},
-                                  {reuseaddr,<%= node['rabbitmq']['tcp_listen_reuseaddr'] %>},
-                                  {backlog,<%= node['rabbitmq']['tcp_listen_backlog'] %>},
-                                  {nodelay,<%= node['rabbitmq']['tcp_listen_nodelay'] %>},
-                                  {exit_on_close,<%= node['rabbitmq']['tcp_listen_exit_on_close'] %>},
-                                  {keepalive,<%= node['rabbitmq']['tcp_listen_keepalive'] %>},
-                                  {linger, {<%= node['rabbitmq']['tcp_listen_linger'] %>,<%= node['rabbitmq']['tcp_listen_linger_timeout'] %>}}]},
+    {tcp_listen_options, [{packet, <%= node['rabbitmq']['tcp_listen_packet'] %>},
+                          {reuseaddr, <%= node['rabbitmq']['tcp_listen_reuseaddr'] %>},
+                          {backlog, <%= node['rabbitmq']['tcp_listen_backlog'] %>},
+                          {nodelay, <%= node['rabbitmq']['tcp_listen_nodelay'] %>},
+                          {exit_on_close, <%= node['rabbitmq']['tcp_listen_exit_on_close'] %>},
+                          {keepalive, <%= node['rabbitmq']['tcp_listen_keepalive'] %>},
+
+                          <% if node['rabbitmq']['tcp_listen_sndbuf'] -%>
+                          {sndbuf, <%= node['rabbitmq']['tcp_listen_sndbuf'] %>},
+                          <% end -%>
+
+                          <% if node['rabbitmq']['tcp_listen_recbuf'] -%>
+                          {recbuf, <%= node['rabbitmq']['tcp_listen_recbuf'] %>},
+                          <% end -%>
+
+                          {linger, {<%= node['rabbitmq']['tcp_listen_linger'] %>,<%= node['rabbitmq']['tcp_listen_linger_timeout'] %>}}]},
 <% else -%>
-   {tcp_listeners, []},
+   {tcp_listen_options, []},
 <% end %>
 
 <% if node['rabbitmq']['log_levels'] -%>
@@ -97,6 +106,10 @@
     {default_user, <<"<%= node['rabbitmq']['default_user'] %>">>},
     {default_pass, <<"<%= node['rabbitmq']['default_pass'] %>">>},
     {heartbeat, <%= node['rabbitmq']['heartbeat'] %>}
+
+<% if node['rabbitmq']['credit_flow_defaults'] -%>
+    {credit_flow_default_credit, {<%= node['rabbitmq']['credit_flow_defaults']['initial'] %>, <%= node['rabbitmq']['credit_flow_defaults']['more_credit_after'] %>}},
+<% end %>
 
     <% node['rabbitmq']['additional_rabbit_configs'].each do |key,value|  -%>
       ,{<%= key %>, <%= value %>}


### PR DESCRIPTION
## Proposed Changes

This PR makes TCP buffer size and credit flow defaults configurable, as requested in #459.

## Types of Changes

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #459.
