### PR TITLE
Expose more TLS socket options, enable them by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -129,6 +129,10 @@ default['rabbitmq']['ssl_versions'] = nil
 # or in OpenSSL format:
 # ['"ECDHE-ECDSA-AES128-SHA256"', '"ECDHE-ECDSA-AES256-SHA"']
 default['rabbitmq']['ssl_ciphers'] = nil
+default['rabbitmq']['ssl_secure_renegotiate'] = true
+default['rabbitmq']['ssl_honor_cipher_order'] = true
+default['rabbitmq']['ssl_honor_ecc_order'] = true
+
 default['rabbitmq']['web_console_ssl'] = false
 default['rabbitmq']['web_console_ssl_port'] = 15_671
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -120,10 +120,33 @@ describe 'rabbitmq::default' do
     end
   end
 
-  describe 'ssl ciphers' do
+  it 'should set additional rabbitmq config' do
+    node.normal['rabbitmq']['additional_rabbit_configs'] = { 'foo' => 'bar' }
+    expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('foo, bar')
+  end
+
+  describe 'TLS configuration' do
     it 'has no ssl ciphers specified by default' do
       expect(chef_run).not_to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
         /{ciphers,[{.*}]}/)
+    end
+
+    it 'enables secure renegotiation by default' do
+      node.normal['rabbitmq']['ssl'] = true
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
+        '{secure_renegotiate, true}')
+    end
+
+    it 'uses server cipher suite preference by default' do
+      node.normal['rabbitmq']['ssl'] = true
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
+        '{honor_cipher_order, true}')
+    end
+
+    it 'uses server ECC curve preference by default' do
+      node.normal['rabbitmq']['ssl'] = true
+      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
+        '{honor_ecc_order, true}')
     end
 
     it 'allows ssl ciphers' do
@@ -151,11 +174,6 @@ describe 'rabbitmq::default' do
       node.normal['rabbitmq']['ssl_listen_interface'] = '0.0.0.0'
       expect(chef_run).not_to render_file('/etc/rabbitmq/rabbitmq.config').with_content(
         /{ssl_listeners, [{"0.0.0.0", 5671}]},/)
-    end
-
-    it 'should set additional rabbitmq config' do
-      node.normal['rabbitmq']['additional_rabbit_configs'] = { 'foo' => 'bar' }
-      expect(chef_run).to render_file('/etc/rabbitmq/rabbitmq.config').with_content('foo, bar')
     end
   end
 

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -60,6 +60,9 @@
                     {fail_if_no_peer_cert,<%= node['rabbitmq']['ssl_fail_if_no_peer_cert'] %>}
                     <% if @ssl_versions -%>,{versions,[<%= @ssl_versions %>]}<% end -%>
                     <% if @ssl_ciphers -%>,{ciphers,[<%= @ssl_ciphers %>]}<% end -%>
+                    <% if node['rabbitmq']['ssl_secure_renegotiate'] -%>,{secure_renegotiate, <%= node['rabbitmq']['ssl_secure_renegotiate'] %>}<% end -%>
+                    <% if node['rabbitmq']['ssl_honor_cipher_order'] -%>,{honor_cipher_order, <%= node['rabbitmq']['ssl_honor_cipher_order'] %>}<% end -%>
+                    <% if node['rabbitmq']['ssl_honor_ecc_order'] -%>,{honor_ecc_order, <%= node['rabbitmq']['ssl_honor_ecc_order'] %>}<% end -%>
                     ]},
 <% end %>
 <% if node['rabbitmq']['tcp_listen'] -%>


### PR DESCRIPTION
## Proposed Changes

This adds support for a several more TLS socket options to ensure
that the recommendations/setup from http://www.rabbitmq.com/ssl.html#tls-evaluation-tools is
possible to achieve with this cookbook.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #240)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Closes #240.
