### PR TITLE
Make rabbitmq_user resources unique

### DIFF
--- a/recipes/user_management.rb
+++ b/recipes/user_management.rb
@@ -24,16 +24,19 @@ include_recipe 'rabbitmq::default'
 include_recipe 'rabbitmq::virtualhost_management'
 
 node['rabbitmq']['enabled_users'].each do |user|
-  rabbitmq_user user['name'] do
+  rabbitmq_user "add-#{user['name']}" do
+    user user['name']
     password user['password']
     action :add
   end
-  rabbitmq_user user['name'] do
+  rabbitmq_user "set-tags-#{user['name']}" do
+    user user['name']
     tag user['tag']
     action :set_tags
   end
   user['rights'].each do |r|
-    rabbitmq_user user['name'] do
+    rabbitmq_user "set-perms-#{user['name']}-vhost-#{Array(r['vhost']).join().gsub('/','_')}" do
+      user user['name']
       vhost r['vhost']
       permissions "#{r['conf']} #{r['write']} #{r['read']}"
       action :set_permissions
@@ -42,7 +45,8 @@ node['rabbitmq']['enabled_users'].each do |user|
 end
 
 node['rabbitmq']['disabled_users'].each do |user|
-  rabbitmq_user user do
+  rabbitmq_user "delete-#{user}" do
+    user user
     action :delete
   end
 end


### PR DESCRIPTION
## Proposed Changes

This PR is designed to fix a resource cloning complaint for `rabbitmq_user`.  Further details can be found in #491 

The `rabbitmq_user` vhost parameter can be a String, Array, or nil as it is optional when action is `:set_permissions`.  I did some IRB testing to verify it handled the cases listed in the README example
```
irb(main):001:0> Array(nil).join().gsub('/','_')
=> ""
irb(main):002:0> Array("/nova").join().gsub('/','_')
=> "_nova"
irb(main):003:0> Array(["/", "/rmq", "/nova"]).join().gsub('/','_')
=> "__rmq_nova"
```

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Fixes #491 