### PR TITLE
Work-around for ssl_ciphers and ssl_versions not working

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -40,14 +40,6 @@ module Opscode
       rendered.each { |r| r }.join(",\n")
     end
 
-    def format_ssl_versions
-      Array(node['rabbitmq']['ssl_versions']).map { |n| "'#{n}'" }.join(',')
-    end
-
-    def format_ssl_ciphers
-      Array(node['rabbitmq']['ssl_ciphers']).join(',')
-    end
-
     def shell_environment
       { 'HOME' => ENV.fetch('HOME', '/var/lib/rabbitmq') }
     end

--- a/libraries/ssl.rb
+++ b/libraries/ssl.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+#
+# Cookbook Name:: rabbitmq
+# Library:: default
+# Author:: Jake Davis (<jake@simple.com>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module Opscode
+  # module rabbit
+  module SSL
+    extend self
+
+    def format_ssl_versions(node)
+      Array(node['rabbitmq']['ssl_versions']).map { |n| "'#{n}'" }.join(',')
+    end
+
+    def format_ssl_ciphers(node)
+      Array(node['rabbitmq']['ssl_ciphers']).join(',')
+    end
+
+  end
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -242,9 +242,7 @@ template "#{node['rabbitmq']['config']}.config" do
   group 'root'
   mode 00644
   variables(
-    :kernel => format_kernel_parameters,
-    :ssl_versions => (format_ssl_versions if node['rabbitmq']['ssl_versions']),
-    :ssl_ciphers => (format_ssl_ciphers if node['rabbitmq']['ssl_ciphers'])
+    :kernel => format_kernel_parameters
   )
   notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
 end

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -19,8 +19,8 @@
                 {ssl_opts, [{cacertfile,"<%= node['rabbitmq']['ssl_cacert'] %>"},
                     {certfile,"<%= node['rabbitmq']['ssl_cert'] %>"},
                     {keyfile,"<%= node['rabbitmq']['ssl_key'] %>"}
-                    <% if @ssl_versions -%>,{versions,[<%= @ssl_versions %>]}<% end -%>
-                    <% if @ssl_ciphers -%>,{ciphers,[<%= @ssl_ciphers %>]}<% end -%>
+                    <% if node['rabbitmq']['ssl_versions'] -%>,{versions,[<%= Opscode::SSL.format_ssl_versions(node) %>]}<% end -%>
+                    <% if node['rabbitmq']['ssl_ciphers'] -%>,{ciphers,[<%= Opscode::SSL.format_ssl_ciphers(node) %>]}<% end -%>
                     ]}
               ]}
   ]},
@@ -37,8 +37,8 @@
     ]}
   ]},
 <% end %>
-<% if node['rabbitmq']['ssl'] && @ssl_versions -%>
-  {ssl, [{versions, [<%= @ssl_versions %>]}]},
+<% if node['rabbitmq']['ssl'] && node['rabbitmq']['ssl_versions'] -%>
+  {ssl, [{versions, [<%= Opscode::SSL.format_ssl_versions(node) %>]}]},
 <% end %>
   {rabbit, [
 <% if node['rabbitmq']['clustering']['enable'] -%>
@@ -58,8 +58,8 @@
                     {keyfile,"<%= node['rabbitmq']['ssl_key'] %>"},
                     {verify,<%= node['rabbitmq']['ssl_verify'] %>},
                     {fail_if_no_peer_cert,<%= node['rabbitmq']['ssl_fail_if_no_peer_cert'] %>}
-                    <% if @ssl_versions -%>,{versions,[<%= @ssl_versions %>]}<% end -%>
-                    <% if @ssl_ciphers -%>,{ciphers,[<%= @ssl_ciphers %>]}<% end -%>
+                    <% if node['rabbitmq']['ssl_versions'] -%>,{versions,[<%= Opscode::SSL.format_ssl_versions(node) %>]}<% end -%>
+                    <% if node['rabbitmq']['ssl_ciphers'] -%>,{ciphers,[<%= Opscode::SSL.format_ssl_ciphers(node) %>]}<% end -%>
                     <% if node['rabbitmq']['ssl_secure_renegotiate'] -%>,{secure_renegotiate, <%= node['rabbitmq']['ssl_secure_renegotiate'] %>}<% end -%>
                     <% if node['rabbitmq']['ssl_honor_cipher_order'] -%>,{honor_cipher_order, <%= node['rabbitmq']['ssl_honor_cipher_order'] %>}<% end -%>
                     <% if node['rabbitmq']['ssl_honor_ecc_order'] -%>,{honor_ecc_order, <%= node['rabbitmq']['ssl_honor_ecc_order'] %>}<% end -%>


### PR DESCRIPTION
## Proposed Changes

Submitting this as a PR, but not expecting it to be merged as is (or necessarily at all because it can likely be fixed in a better way). _However_, I'm thinking/hoping that the PR explains better the issue we were seeing and if someone can guide me to fix it in a more Chef-y way then I'll re-work it so it can be merged.

In upgrading our Sensu RabbitMQ from 3.7.6 to 3.7.9 we found we needed to set `ssl_ciphers` and `ssl_versions` in the `rabbitmq.config`. Setting those node attributes didn't actually work. We could see they were set via `chef-shell -z`, but they didn't get applied to the config. This was with version 5.6.1 of the cookbook. On investigation we found `@ssl_version`, etc wasn't working in the erb template so came up with this PR'd work-around that we could use internally for the time being.

It looks like this is the same issue as per #388 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Versions

- Chef version: 12.10.24
- Cookbook version: 5.6.1
- Node attributes (as many as possible, make sure to edit out sensitive information):

```
chef (12.10.24)> node["rabbitmq"]
 => {"version"=>"3.7.9", "use_distro_version"=>false, "pin_distro_version"=>false, "deb_package"=>nil, "deb_package_url"=>nil, "rpm_package"=>nil, "rpm_package_url"=>nil, "esl-erlang_package"=>"esl-erlang-compat-R16B03-1.noarch.rpm?raw=true", "esl-erlang_package_url"=>"https://github.com/jasonmcintosh/esl-erlang-compat/blob/master/rpmbuild/RPMS/noarch/", "nodename"=>nil, "address"=>nil, "port"=>5672, "config"=>"/etc/rabbitmq/rabbitmq", "logdir"=>nil, "server_additional_erl_args"=>nil, "ctl_erl_args"=>nil, "mnesiadir"=>"/var/lib/rabbitmq/mnesia", "service_name"=>"rabbitmq-server", "manage_service"=>true, "retry"=>0, "retry_delay"=>2, "config_root"=>"/etc/rabbitmq", "erlang_cookie_path"=>"/var/lib/rabbitmq/.erlang.cookie", "erlang_cookie"=>"REDACTED", "config_template_cookbook"=>"rabbitmq", "config-env_template_cookbook"=>"rabbitmq", "default_user"=>"guest", "default_pass"=>"guest", "loopback_users"=>nil, "kernel"=>{"inet_dist_listen_min"=>nil, "inet_dist_listen_max"=>nil, "inet_dist_use_interface"=>nil}, "clustering"=>{"enable"=>true, "cluster_partition_handling"=>"pause_minority", "use_auto_clustering"=>false, "cluster_name"=>"REDACTED", "cluster_nodes"=>[{"name"=>"rabbit@REDACTED-2", "type"=>"disc"}, {"name"=>"rabbit@REDACTED-1", "type"=>"disc"}, {"name"=>"rabbit@REDACTED-0", "type"=>"disc"}], "node_type"=>"master", "master_node_name"=>"rabbit@rabbit1", "cluster_node_type"=>"disc"}, "log_levels"=>{"connection"=>"info"}, "logrotate"=>{"enable"=>true, "path"=>"/var/log/rabbitmq/*.log", "rotate"=>20, "frequency"=>"weekly", "options"=>["missingok", "notifempty", "delaycompress"], "sharedscripts"=>true, "postrotate"=>"/usr/sbin/rabbitmqctl rotate_logs > /dev/null"}, "disk_free_limit_relative"=>nil, "disk_free_limit"=>nil, "vm_memory_high_watermark"=>nil, "max_file_descriptors"=>1024, "open_file_limit"=>nil, "job_control"=>"initd", "ssl"=>true, "ssl_port"=>5671, "ssl_listen_interface"=>nil, "ssl_cacert"=>"/etc/rabbitmq/ssl/cacert.pem", "ssl_cert"=>"/etc/rabbitmq/ssl/cert.pem", "ssl_key"=>"/etc/rabbitmq/ssl/key.pem", "ssl_verify"=>"verify_peer", "ssl_fail_if_no_peer_cert"=>true, "ssl_versions"=>"tlsv1.2", "ssl_ciphers"=>"{rsa,aes_256_cbc,sha256}", "ssl_secure_renegotiate"=>true, "ssl_honor_cipher_order"=>true, "ssl_honor_ecc_order"=>true, "web_console_ssl"=>false, "web_console_ssl_port"=>15671, "management"=>{"load_definitions"=>false, "definitions_file"=>"/etc/rabbitmq/load_definitions.json"}, "web_console_port"=>15672, "web_console_interface"=>nil, "tcp_listen"=>true, "tcp_listen_interface"=>nil, "tcp_listen_packet"=>"raw", "tcp_listen_reuseaddr"=>true, "tcp_listen_backlog"=>128, "tcp_listen_nodelay"=>true, "tcp_listen_exit_on_close"=>false, "tcp_listen_keepalive"=>false, "tcp_listen_linger"=>true, "tcp_listen_linger_timeout"=>0, "tcp_listen_buffer"=>nil, "tcp_listen_sndbuf"=>nil, "tcp_listen_recbuf"=>nil, "virtualhosts"=>[], "disabled_virtualhosts"=>[], "enabled_users"=>[{"name"=>"guest", "password"=>"guest", "rights"=>[{"vhost"=>nil, "conf"=>".*", "write"=>".*", "read"=>".*"}]}], "disabled_users"=>[], "enabled_plugins"=>[], "disabled_plugins"=>[], "community_plugins"=>{}, "systemd_unit_root"=>"/etc/systemd/system/rabbitmq-server.service.d", "systemd"=>{"limits"=>{"NOFILE"=>500000}}, "heartbeat"=>60, "policies"=>{}, "disabled_policies"=>[], "conf"=>{}, "additional_rabbit_configs"=>{}, "access"=>{"sensu_client"=>["0.0.0.0/0"], "management"=>["127.0.0.1"]}, "listen_interface"=>"eth0"} 
```

Note the Erlang version actually used is:

```
chef (12.10.24)> node['erlang']['esl']['version']
 => "1:21.*" 
```

```
$erl
Erlang/OTP 21 [erts-10.1.3] [source] [64-bit] [smp:2:2] [ds:2:2:10] [async-threads:1] [hipe]
Eshell V10.1.3  (abort with ^G) 
```

- RabbitMQ server version(s) you target: 3.7.9
- Erlang version used: 21.1.4
- Operating system version (and distribution, if applicable): Ubuntu Trusty 14.04 and 16.04
- What RabbitMQ plugins are used, in particular 3rd party ones: N/A

## Further Comments

See following text from the commit.

---

Moving from RabbitMQ 3.7.6 to 3.7.9 in our Sensu installation "broke"
Sensu with the RabbitMQ reporting:

```
TLS server: In state hello at tls_handshake.erl:200 generated SERVER ALERT: Fatal - Insufficient Security - no_suitable_ciphers
```

Checking the [Sensu docs](https://docs.sensu.io/sensu-core/1.6/reference/ssl/#enable-rabbitmq-ssl-support) they state to use:

```
[...]
{versions, ['tlsv1.2']},
{ciphers,  [{rsa,aes_256_cbc,sha256}]},
[...]
```

in the `/etc/rabbitmq/rabbitmq.config`. We had not been setting these
previously; We just had `cacertfile`, `certfile`, `keyfile` and this was
fine under 3.7.6; Checking the RabbitMQ changelog there do appear to
have been TLS changes between 3.7.6 and 3.7.9.

Therefore we tried to set the `ssl_ciphers` and `ssl_versions` in the
cookbook:

```
node.override["rabbitmq"]["ssl_ciphers"] = '{rsa,aes_256_cbc,sha256}'
node.override["rabbitmq"]["ssl_versions"] = "tlsv1.2"
```

But the 5.6.1 cookbook would not pick these up. We can see they are set
correctly via `chef-shell -z` on the host, but they did not get applied
to the `rabbitmq.config`. For some reason this:

```
template "#{node['rabbitmq']['config']}.config" do
[...]
  variables(
    :kernel => format_kernel_parameters,
    :ssl_versions => (format_ssl_versions if node['rabbitmq']['ssl_versions']),
    :ssl_ciphers => (format_ssl_ciphers if node['rabbitmq']['ssl_ciphers'])
  )
[...]
```

does not work. In the erb template `@ssl_versions`, etc, must be `nil`
because that part of the template gets skipped over.

Tried a few different things to get it to work and in the end this
seemed the least hacky way of getting it to work although it's still not
"Chef-y".

- Move the `format_ssl_versions` and `format_ssl_ciphers` to a separate
module
- Remove `ssl_versions` and `ssl_ciphers` from variables in
rabbitmq config template section
- In erb template check for `node['rabbitmq']['ssl_versions']`, etc drectly instead
of using `@ssl_versions`
- In erb template call the methods in the new ssl module directly as
`Opscode::SSL.format_ssl_versions(node)`, etc instead of using `@ssl_versions`, etc. It's necessary to pass through `node` as we lose some Chef magic since we are just trying to use this as a plain module instead of mixing into Chef stuff.
- Bump metadata (although this was just for internal usage)

References: https://github.com/rabbitmq/chef-cookbook/issues/388