### PR TITLE
append `.config` to rabbitmq-env.conf.erb `CONFIG_FILE` line

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,7 @@ default['rabbitmq']['retry_delay'] = 2
 
 # config file location
 # http://www.rabbitmq.com/configure.html#define-environment-variables
-# "The .config extension is automatically appended by the Erlang runtime."
+# "The .config extension is automatically appended unless a file extension is already present."
 default['rabbitmq']['config_root'] = '/etc/rabbitmq'
 default['rabbitmq']['config'] = "#{node['rabbitmq']['config_root']}/rabbitmq"
 default['rabbitmq']['erlang_cookie_path'] = '/var/lib/rabbitmq/.erlang.cookie'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -51,5 +51,10 @@ module Opscode
     def shell_environment
       { 'HOME' => ENV.fetch('HOME', '/var/lib/rabbitmq') }
     end
+
+    def config_path
+      return "#{node['rabbitmq']['config']}.config" if ::File.extname(node['rabbitmq']['config']) == ""
+      node['rabbitmq']['config']
+    end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -232,9 +232,12 @@ template "#{node['rabbitmq']['config_root']}/rabbitmq-env.conf" do
   group 'root'
   mode 00644
   notifies :restart, "service[#{node['rabbitmq']['service_name']}]"
+  variables(
+    :config_path => config_path
+  )
 end
 
-template "#{node['rabbitmq']['config']}.config" do
+template config_path do
   sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
   source 'rabbitmq.config.erb'
   cookbook node['rabbitmq']['config_template_cookbook']

--- a/templates/default/rabbitmq-env.conf.erb
+++ b/templates/default/rabbitmq-env.conf.erb
@@ -15,7 +15,7 @@ export ERL_EPMD_ADDRESS=<%= node['rabbitmq']['erl_networking_bind_address'] %>
 <% if node['rabbitmq']['nodename'] -%>NODENAME=<%= node['rabbitmq']['nodename'] %><% end %>
 <% end -%>
 <% if node['rabbitmq']['port'] -%>NODE_PORT=<%= node['rabbitmq']['port'] %><% end %>
-<% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= node['rabbitmq']['config'] %><% end %>
+<% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= node['rabbitmq']['config'] %>.config<% end %>
 <% if node['rabbitmq']['logdir'] -%>LOG_BASE=<%= node['rabbitmq']['logdir'] %><% end %>
 <% if node['rabbitmq']['mnesiadir'] -%>MNESIA_BASE=<%= node['rabbitmq']['mnesiadir'] %><% end %>
 <% if node['rabbitmq']['server_additional_erl_args'] -%>SERVER_ADDITIONAL_ERL_ARGS='<%= node['rabbitmq']['server_additional_erl_args'] %>'<% end %>

--- a/templates/default/rabbitmq-env.conf.erb
+++ b/templates/default/rabbitmq-env.conf.erb
@@ -15,7 +15,7 @@ export ERL_EPMD_ADDRESS=<%= node['rabbitmq']['erl_networking_bind_address'] %>
 <% if node['rabbitmq']['nodename'] -%>NODENAME=<%= node['rabbitmq']['nodename'] %><% end %>
 <% end -%>
 <% if node['rabbitmq']['port'] -%>NODE_PORT=<%= node['rabbitmq']['port'] %><% end %>
-<% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= node['rabbitmq']['config'] %>.config<% end %>
+<% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= @config_path %>.config<% end %>
 <% if node['rabbitmq']['logdir'] -%>LOG_BASE=<%= node['rabbitmq']['logdir'] %><% end %>
 <% if node['rabbitmq']['mnesiadir'] -%>MNESIA_BASE=<%= node['rabbitmq']['mnesiadir'] %><% end %>
 <% if node['rabbitmq']['server_additional_erl_args'] -%>SERVER_ADDITIONAL_ERL_ARGS='<%= node['rabbitmq']['server_additional_erl_args'] %>'<% end %>

--- a/templates/default/rabbitmq-env.conf.erb
+++ b/templates/default/rabbitmq-env.conf.erb
@@ -15,7 +15,7 @@ export ERL_EPMD_ADDRESS=<%= node['rabbitmq']['erl_networking_bind_address'] %>
 <% if node['rabbitmq']['nodename'] -%>NODENAME=<%= node['rabbitmq']['nodename'] %><% end %>
 <% end -%>
 <% if node['rabbitmq']['port'] -%>NODE_PORT=<%= node['rabbitmq']['port'] %><% end %>
-<% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= @config_path %>.config<% end %>
+<% if node['rabbitmq']['config'] -%>CONFIG_FILE=<%= @config_path %><% end %>
 <% if node['rabbitmq']['logdir'] -%>LOG_BASE=<%= node['rabbitmq']['logdir'] %><% end %>
 <% if node['rabbitmq']['mnesiadir'] -%>MNESIA_BASE=<%= node['rabbitmq']['mnesiadir'] %><% end %>
 <% if node['rabbitmq']['server_additional_erl_args'] -%>SERVER_ADDITIONAL_ERL_ARGS='<%= node['rabbitmq']['server_additional_erl_args'] %>'<% end %>


### PR DESCRIPTION
This change is to update line #18 in `templates/default/rabbitmq-env.conf.erb` to append the `.config` suffix to the value of `node['rabbitmq']['config']`

As per https://github.com/rabbitmq/chef-cookbook/blob/v5.x/recipes/default.rb#L237 the generated config file will always be at `#{node['rabbitmq']['config']}.config` and not at simply `node['rabbitmq']['config']`

Without this change `rabbitmq-env.conf` will never properly handle a non-default setting for the value of `node['rabbitmq']['config']`