### PR TITLE
simplify version specific switchcase for rabbitmqctl commands

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -72,6 +72,14 @@ module RabbitMQ
       rabbitmq_version =~ /^3.6/
     end
 
+    def installed_rabbitmq_version
+      # output a rabbitmq-server version string excluding anything after the "-"
+      # (distro specific builds might contain additional non semver compatible
+      # versioning that we can not interpret in this cookbook)
+      # e.g. "3.7.13"
+      node['packages']['rabbitmq-server']['version'][/[^-]+/]
+    end
+
     def rabbitmq_config_file_path
       configured_path = node['rabbitmq']['config']
 

--- a/providers/parameter.rb
+++ b/providers/parameter.rb
@@ -26,7 +26,7 @@ include RabbitMQ::CoreHelpers
 use_inline_resources if defined?(:use_inline_resources) # ~FC113
 
 def parameter_exists?(vhost, name)
-  cmd = if rabbitmq_37? && !use_distro_version? && node['rabbitmq']['version'] >= '3.7.10'
+  cmd = if Gem::Version.new(installed_rabbitmq_version) >= Gem::Version.new('3.7.10')
           'rabbitmqctl list_parameters -s'
         else
           'rabbitmqctl list_parameters -q'

--- a/providers/policy.rb
+++ b/providers/policy.rb
@@ -26,7 +26,7 @@ include RabbitMQ::CoreHelpers
 use_inline_resources if defined?(:use_inline_resources) # ~FC113
 
 def policy_exists?(vhost, name)
-  cmd = if rabbitmq_37? && !use_distro_version? && node['rabbitmq']['version'] >= '3.7.10'
+  cmd = if Gem::Version.new(installed_rabbitmq_version) >= Gem::Version.new('3.7.10')
           'rabbitmqctl list_policies -s'
         else
           'rabbitmqctl list_policies -q'

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -23,7 +23,7 @@ include RabbitMQ::CoreHelpers
 use_inline_resources if defined?(:use_inline_resources) # ~FC113
 
 def user_exists?(name)
-  cmd = if rabbitmq_37? && !use_distro_version? && node['rabbitmq']['version'] >= '3.7.10'
+  cmd = if Gem::Version.new(installed_rabbitmq_version) >= Gem::Version.new('3.7.10')
           "rabbitmqctl -s list_users |grep '^#{name}\\s'"
         else
           "rabbitmqctl -q list_users |grep '^#{name}\\s'"
@@ -41,7 +41,7 @@ def user_exists?(name)
 end
 
 def user_has_tag?(name, tag)
-  cmd = if rabbitmq_37? && !use_distro_version? && node['rabbitmq']['version'] >= '3.7.10'
+  cmd = if Gem::Version.new(installed_rabbitmq_version) >= Gem::Version.new('3.7.10')
           'rabbitmqctl -s list_users'
         else
           'rabbitmqctl -q list_users'
@@ -68,7 +68,7 @@ end
 # empty perm_list means we're checking for any permissions
 def user_has_permissions?(name, vhost, perm_list = nil)
   vhost = '/' if vhost.nil? # rubocop:enable all
-  cmd = if rabbitmq_37? && !use_distro_version? && node['rabbitmq']['version'] >= '3.7.10'
+  cmd = if Gem::Version.new(installed_rabbitmq_version) >= Gem::Version.new('3.7.10')
           "rabbitmqctl -s list_user_permissions #{name} | grep \"^#{vhost}\\s\""
         else
           "rabbitmqctl -q list_user_permissions #{name} | grep \"^#{vhost}\\s\""

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -339,3 +339,11 @@ else
     action :nothing
   end
 end
+
+# after installing rabbitmq-server, reload the 'packages' automatic attributes
+# from ohai, since this is used as base to figure out the proper parameters for
+# interacting with the version specific rabbitmqctl
+ohai 'reload_packages' do
+  action :reload
+  plugin 'packages'
+end


### PR DESCRIPTION
## Proposed Changes

* add method to parse 'rabbitmq-server' package version from automatic
ohai attributes
* add ohai attribute reload after installing rabbitmq-server package to
allow usage of before mentioned logic in the same chef-client run
* introduce version comparison using 'Gem::Version.new()' to allow
correct comparison of semver compatible version strings

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments