### PR TITLE
URL Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ to them.
 
 This cookbook is set up to run tests under
 [Kitchen-ci's test-kitchen](https://github.com/test-kitchen/test-kitchen).
-It uses [inspec](http://inspec.io) to perform integration tests after the node
+It uses [inspec](https://inspec.io) to perform integration tests after the node
 has been converged.
 
 Test kitchen should run completely without exception using the default
@@ -182,7 +182,7 @@ The versioning for Chef Cookbook projects is X.Y.Z.
 
 Releases of Chef's cookbooks are usually announced on the Chef user
 mailing list. Releases of several cookbooks may be batched together
-and announced on the [Chef Blog](http://www.chef.io/blog).
+and announced on the [Chef Blog](https://www.chef.io/blog).
 
 ## Working with the community
 
@@ -190,18 +190,18 @@ These resources will help you learn more about Chef and connect to
 other members of the Chef community:
 
 * [openstack cookbook group](https://groups.google.com/forum/#!forum/opscode-chef-openstack)
-* [chef](http://lists.chef.io/sympa/info/chef) and
-  [chef-dev](http://lists.chef.io/sympa/info/chef-dev) mailing
+* [chef](http://lists.opscode.com/sympa/info/chef) and
+  [chef-dev](http://lists.opscode.com/sympa/info/chef-dev) mailing
   lists
 * #openstack-chef, #chef, #chef-hacking IRC channels on irc.freenode.net
-* Chef, Inc [product page](http://www.chef.io/chef)
+* Chef, Inc [product page](https://www.chef.io/chef)
 
 ## Cookbook Contribution Do's and Don't's
 
 Please do include tests for your contribution. If you need help, ask
 on the [openstack cookbook group](https://groups.google.com/forum/#!forum/opscode-chef-openstack)
-or the [chef-dev mailing list](http://lists.chef.io/sympa/info/chef-dev)
-or the [#chef-hacking IRC channel](http://community.chef.io/chat/chef-hacking).
+or the [chef-dev mailing list](http://lists.opscode.com/sympa/info/chef-dev)
+or the [#chef-hacking IRC channel](https://community.chef.io/chat/chef-hacking).
 
 Not all platforms that a cookbook supports may be supported by Test
 Kitchen. Please provide evidence of testing your contribution if it

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ will go out of vendor support in 2019.
 ## Dependencies
 
 This cookbook depends on the [Erlang cookbook](https://supermarket.chef.io/cookbooks/erlang)
-and assumes that the user can configure it to provision a [supported Erlang/OTP version](http://www.rabbitmq.com/which-erlang.html).
+and assumes that the user can configure it to provision a [supported Erlang/OTP version](https://www.rabbitmq.com/which-erlang.html).
 
 Two more recipes are provided by this cookbook:`rabbitmq::erlang_package` and `rabbitmq::esl_erlang_package`.
 The latter is an alias to the `erlang::esl` recipe in the Erlang
@@ -274,9 +274,9 @@ in the RabbitMQ [Access Control guide](https://www.rabbitmq.com/access-control.h
 
 ##### Definitions Import
 
-[RabbitMQ management plugin](http://www.rabbitmq.com/management.html) provides a means to load a definitions
-(schema) file on node boot. See [Definitions Export and Import](http://www.rabbitmq.com/management.html#load-definitions)
-and [Backup](http://www.rabbitmq.com/backup.html) guides for details.
+[RabbitMQ management plugin](https://www.rabbitmq.com/management.html) provides a means to load a definitions
+(schema) file on node boot. See [Definitions Export and Import](https://www.rabbitmq.com/management.html#load-definitions)
+and [Backup](https://www.rabbitmq.com/backup.html) guides for details.
 
 To configure definition loading, set the following attribute:
 
@@ -327,7 +327,7 @@ node['rabbitmq']['enabled_users'] = [
 Note that with this approach user credentials will be stored in the attribute file.
 Using encrypted data bags is therefore highly recommended.
 
-Alternatively [definitions export and import](http://www.rabbitmq.com/management.html#load-definitions) (see above) can be used.
+Alternatively [definitions export and import](https://www.rabbitmq.com/management.html#load-definitions) (see above) can be used.
 Definition files contain password hashes since clear text values are not stored.
 
 ### vhosts
@@ -339,7 +339,7 @@ Configures a cluster of nodes.
 
 It supports two clustering modes: auto or manual.
 
-* Auto clustering: lists [cluster nodes in the RabbitMQ config file](http://www.rabbitmq.com/cluster-formation.html#peer-discovery-classic-config). Those are taken from lists the nodes `node['rabbitmq']['clustering']['cluster_nodes']`.
+* Auto clustering: lists [cluster nodes in the RabbitMQ config file](https://www.rabbitmq.com/cluster-formation.html#peer-discovery-classic-config). Those are taken from lists the nodes `node['rabbitmq']['clustering']['cluster_nodes']`.
 * Manual clustering : Configure the cluster by executing `rabbitmqctl join_cluster` command.
 
 #### Attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,7 +55,7 @@ default['rabbitmq']['retry'] = 0
 default['rabbitmq']['retry_delay'] = 2
 
 # config file location
-# http://www.rabbitmq.com/configure.html#define-environment-variables
+# https://www.rabbitmq.com/configure.html#define-environment-variables
 # "The .config extension is automatically appended unless a file extension is already present."
 default['rabbitmq']['config_root'] = '/etc/rabbitmq'
 default['rabbitmq']['config'] = "#{node['rabbitmq']['config_root']}/rabbitmq"
@@ -76,7 +76,7 @@ default['rabbitmq']['default_pass'] = 'guest'
 default['rabbitmq']['loopback_users'] = nil
 
 ## Erlang kernel application options
-## See http://www.erlang.org/doc/man/kernel_app.html
+## See https://www.erlang.org/doc/man/kernel_app.html
 default['rabbitmq']['kernel']['inet_dist_listen_min'] = nil
 default['rabbitmq']['kernel']['inet_dist_listen_max'] = nil
 
@@ -96,7 +96,7 @@ default['rabbitmq']['clustering']['cluster_nodes'] = []
 ## Chef-driven clustering.
 ##
 ## Note that there are no leader/master or follower nodes in RabbitMQ,
-## all nodes are equal peers: http://www.rabbitmq.com/clustering.html#peer-equality
+## all nodes are equal peers: https://www.rabbitmq.com/clustering.html#peer-equality
 default['rabbitmq']['clustering']['node_type']         = 'master'
 default['rabbitmq']['clustering']['master_node_name']  = 'rabbit@rabbit1'
 default['rabbitmq']['clustering']['cluster_node_type'] = 'disc'

--- a/test/erlang_package/latest_deb/default_spec.rb
+++ b/test/erlang_package/latest_deb/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 %w(
   erlang-asn1 erlang-crypto erlang-public-key erlang-ssl erlang-syntax-tools

--- a/test/erlang_package/latest_rpm/default_spec.rb
+++ b/test/erlang_package/latest_rpm/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 describe package('erlang') do
   it { should be_installed }

--- a/test/erlang_package/pinned_deb/default_spec.rb
+++ b/test/erlang_package/pinned_deb/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 %w(
   erlang-asn1 erlang-crypto erlang-public-key erlang-ssl erlang-syntax-tools

--- a/test/erlang_package/pinned_rpm/default_spec.rb
+++ b/test/erlang_package/pinned_rpm/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 describe package('erlang') do
   it { should be_installed }

--- a/test/integration/cluster/default_spec.rb
+++ b/test/integration/cluster/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 describe file('/var/lib/rabbitmq/.erlang.cookie') do
   it { should be_file }

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 describe package('rabbitmq-server') do
   it { should be_installed }

--- a/test/integration/limits/default_spec.rb
+++ b/test/integration/limits/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 describe package('rabbitmq-server') do
   it { should be_installed }

--- a/test/integration/lwrps/default_spec.rb
+++ b/test/integration/lwrps/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 describe command('curl -u guest:guest -H "Accept: application/json" -X GET "http://localhost:15672/api/overview"') do
   its(:exit_status) { should eq 0 }

--- a/test/integration/management_plugin/default_spec.rb
+++ b/test/integration/management_plugin/default_spec.rb
@@ -1,5 +1,5 @@
 # The Inspec reference, with examples and extensive documentation, can be
-# found at http://inspec.io/docs/reference/resources/
+# found at https://inspec.io/docs/reference/resources/
 
 describe package('rabbitmq-server') do
   it { should be_installed }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://lists.chef.io/sympa/info/chef (301) with 1 occurrences could not be migrated:  
   ([https](https://lists.chef.io/sympa/info/chef) result ConnectTimeoutException).
* http://lists.chef.io/sympa/info/chef-dev (301) with 2 occurrences could not be migrated:  
   ([https](https://lists.chef.io/sympa/info/chef-dev) result ConnectTimeoutException).
* http://sample.com/rabbitmq_community_plugin.ez (404) with 2 occurrences could not be migrated:  
   ([https](https://sample.com/rabbitmq_community_plugin.ez) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://community.chef.io/chat/chef-hacking (UnknownHostException) with 1 occurrences migrated to:  
  https://community.chef.io/chat/chef-hacking ([https](https://community.chef.io/chat/chef-hacking) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.rabbitmq.com/backup.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/backup.html ([https](https://www.rabbitmq.com/backup.html) result 200).
* http://www.rabbitmq.com/cluster-formation.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/cluster-formation.html ([https](https://www.rabbitmq.com/cluster-formation.html) result 200).
* http://www.rabbitmq.com/clustering.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/clustering.html ([https](https://www.rabbitmq.com/clustering.html) result 200).
* http://www.rabbitmq.com/configure.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/configure.html ([https](https://www.rabbitmq.com/configure.html) result 200).
* http://www.rabbitmq.com/management.html with 3 occurrences migrated to:  
  https://www.rabbitmq.com/management.html ([https](https://www.rabbitmq.com/management.html) result 200).
* http://www.rabbitmq.com/which-erlang.html with 1 occurrences migrated to:  
  https://www.rabbitmq.com/which-erlang.html ([https](https://www.rabbitmq.com/which-erlang.html) result 200).
* http://inspec.io with 1 occurrences migrated to:  
  https://inspec.io ([https](https://inspec.io) result 301).
* http://inspec.io/docs/reference/resources/ with 9 occurrences migrated to:  
  https://inspec.io/docs/reference/resources/ ([https](https://inspec.io/docs/reference/resources/) result 301).
* http://www.chef.io/blog with 1 occurrences migrated to:  
  https://www.chef.io/blog ([https](https://www.chef.io/blog) result 301).
* http://www.chef.io/chef with 1 occurrences migrated to:  
  https://www.chef.io/chef ([https](https://www.chef.io/chef) result 301).
* http://www.erlang.org/doc/man/kernel_app.html with 1 occurrences migrated to:  
  https://www.erlang.org/doc/man/kernel_app.html ([https](https://www.erlang.org/doc/man/kernel_app.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost:15672/api/overview with 1 occurrences