### PR TITLE
Fix policy pattern typo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -219,7 +219,7 @@ default['rabbitmq']['policies'] = {}
 default['rabbitmq']['disabled_policies'] = []
 
 # Example HA policies
-# default['rabbitmq']['policies']['ha-all']['pattern'] = '^(?!amq\\.).*'
+# default['rabbitmq']['policies']['ha-all']['pattern'] = '^(?!amq\.).*'
 # default['rabbitmq']['policies']['ha-all']['params'] = { 'ha-mode' => 'all' }
 # default['rabbitmq']['policies']['ha-all']['priority'] = 0
 #


### PR DESCRIPTION
Queues matching this pattern are e.g. `amq.direct` and do not contain an
actual `\` character.

## Proposed Changes

The current example policy pattern looks wrong. However, I am not 100% certain.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories