### PR TITLE
Fix README typo on rpm package attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Set `node['rabbitmq']['version']` to specify a version:
 node['rabbitmq']['version'] = "3.7.13"
 ```
 
-If you have `node['rabbitmq']['deb_package_url']` or `node['rabbitmq']['deb_package_url']` overridden
+If you have `node['rabbitmq']['deb_package_url']` or `node['rabbitmq']['rpm_package_url']` overridden
 from earlier versions, consider omitting those attributes. Otherwise see a section on download
 location customization below.
 
@@ -236,7 +236,7 @@ node['rabbitmq']['ssl_listen_interface'] = nil
 
 #### Custom Package Download Locations
 
-`node['rabbitmq']['deb_package_url']` and `node['rabbitmq']['deb_package_url']` can be used
+`node['rabbitmq']['deb_package_url']` and `node['rabbitmq']['rpm_package_url']` can be used
 to override the package download location. They configure a prefix without a version.
 Set them to a download location without a version if you want to provision from a custom
 endpoint such as a local mirror.


### PR DESCRIPTION
## Proposed Changes

Fix a typo in the README on custom package download locations for RPM-based packages.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

No tests run, as it's only a README change.