### PR TITLE
Setting a password starting with "&" fails

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer 'Chef, Inc. and contributors'
 maintainer_email 'mklishin@pivotal.io'
 license 'Apache-2.0'
 description 'Installs and configures RabbitMQ server'
-version '5.8.0'
+version '5.8.1'
 
 recipe 'rabbitmq', 'Install and configure RabbitMQ'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer 'Chef, Inc. and contributors'
 maintainer_email 'mklishin@pivotal.io'
 license 'Apache-2.0'
 description 'Installs and configures RabbitMQ server'
-version '5.8.1'
+version '5.8.0'
 
 recipe 'rabbitmq', 'Install and configure RabbitMQ'
 

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -177,7 +177,7 @@ end
 
 action :change_password do
   if user_exists?(new_resource.user)
-    cmd = "rabbitmqctl -q change_password #{new_resource.user} #{new_resource.password}"
+    cmd = "rabbitmqctl -q change_password #{new_resource.user} \"#{new_resource.password}\""
     execute "rabbitmqctl -q change_password #{new_resource.user}" do # ~FC009
       sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
       command cmd

--- a/providers/user.rb
+++ b/providers/user.rb
@@ -177,7 +177,8 @@ end
 
 action :change_password do
   if user_exists?(new_resource.user)
-    cmd = "rabbitmqctl -q change_password #{new_resource.user} \"#{new_resource.password}\""
+    new_password = new_resource.password.gsub("'", "'\\\\''")
+    cmd = "rabbitmqctl -q change_password #{new_resource.user} '#{new_password}'"
     execute "rabbitmqctl -q change_password #{new_resource.user}" do # ~FC009
       sensitive true if Gem::Version.new(Chef::VERSION.to_s) >= Gem::Version.new('11.14.2')
       command cmd


### PR DESCRIPTION
## Proposed Changes

This is just a tiny change that quotes the password when being passed to the execute resource for the change password operation. Otherwise a special character like "&" at the beginning of the password will break the command execution.
