### PR TITLE
Use strings for pin_priority to be compatible with the apt cookbook

### DIFF
--- a/providers/erlang_apt_repository_on_bintray.rb
+++ b/providers/erlang_apt_repository_on_bintray.rb
@@ -39,7 +39,7 @@ action :add do
   apt_preference(new_resource.name) do
     glob 'erlang*'
     pin 'release o=Bintray'
-    pin_priority 800
+    pin_priority '800'
 
     action :add
   end

--- a/providers/erlang_package_from_bintray.rb
+++ b/providers/erlang_package_from_bintray.rb
@@ -42,7 +42,7 @@ action :install do
         apt_preference "#{new_resource.name}-#{p}" do
           package_name p
           pin "version #{new_resource.version}"
-          pin_priority 900
+          pin_priority '900'
           action :add
           not_if { new_resource.version.nil? }
         end


### PR DESCRIPTION
## Proposed Changes

Change `pin_priority` to a string to be compatible with the [apt cookbook](https://supermarket.chef.io/cookbooks/apt). While [the native resource](https://docs.chef.io/resource_apt_preference.html) (introduced in Chef 13.3) supports both strings and integers, the [old apt cookbook](https://github.com/chef-cookbooks/apt/blob/v5.1.0/resources/preference.rb#L31) only supports strings.

I'm forced to use Chef 12 currently, and version 5.1.0 of the apt cookbook. I confirmed that changing this to strings resolves the issue.

## Types of Changes

- [x] Bug fix

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Should affect very few users.

Here's the error from chef:

```
Chef::Exceptions::ValidationFailed
----------------------------------
Option pin_priority must be a kind of [String]!  You passed 800.
```
