### PR TITLE
Don't install erlang-ftp and erlang-tftp to fix xenial

### DIFF
--- a/providers/erlang_package_from_bintray.rb
+++ b/providers/erlang_package_from_bintray.rb
@@ -24,7 +24,7 @@ provides :erlang_package_from_bintray, platform_family: %w(debian ubuntu rhel ce
 
 DEBIAN_PACKAGES = %w(erlang-mnesia erlang-runtime-tools erlang-asn1 erlang-crypto erlang-public-key erlang-ssl
                      erlang-syntax-tools erlang-snmp erlang-os-mon erlang-parsetools
-                     erlang-ftp erlang-tftp erlang-inets erlang-tools erlang-eldap erlang-xmerl
+                     erlang-inets erlang-tools erlang-eldap erlang-xmerl
                      erlang-dev erlang-edoc erlang-eunit erlang-erl-docgen erlang-src).freeze
 
 action :install do

--- a/providers/erlang_package_from_bintray.rb
+++ b/providers/erlang_package_from_bintray.rb
@@ -37,6 +37,7 @@ action :install do
 
     erlang_packages = [base_pkg] + DEBIAN_PACKAGES
 
+    # xenial does not have these packages
     if node['rabbitmq']['erlang']['apt']['lsb_codename'] == 'xenial'
       erlang_packages -= %w(erlang-ftp erlang-tftp)
     end

--- a/providers/erlang_package_from_bintray.rb
+++ b/providers/erlang_package_from_bintray.rb
@@ -24,7 +24,7 @@ provides :erlang_package_from_bintray, platform_family: %w(debian ubuntu rhel ce
 
 DEBIAN_PACKAGES = %w(erlang-mnesia erlang-runtime-tools erlang-asn1 erlang-crypto erlang-public-key erlang-ssl
                      erlang-syntax-tools erlang-snmp erlang-os-mon erlang-parsetools
-                     erlang-inets erlang-tools erlang-eldap erlang-xmerl
+                     erlang-ftp erlang-tftp erlang-inets erlang-tools erlang-eldap erlang-xmerl
                      erlang-dev erlang-edoc erlang-eunit erlang-erl-docgen erlang-src).freeze
 
 action :install do
@@ -36,6 +36,10 @@ action :install do
     end
 
     erlang_packages = [base_pkg] + DEBIAN_PACKAGES
+
+    if node['rabbitmq']['erlang']['apt']['lsb_codename'] == 'xenial'
+      erlang_packages -= %w(erlang-ftp erlang-tftp)
+    end
 
     unless new_resource.version.nil?
       erlang_packages.each do |p|


### PR DESCRIPTION
## Proposed Changes

Hi, this is as much a question as a possible solution. It does not appear that erlang-ftp and erlang-tftp are available for Ubuntu 16.04 (xenial) in the rabbitmq-erlang repository.

The files `erlang-ftp_21.3.8.2-1_amd64.deb` and `erlang-tftp_21.3.8.2-1_amd64.deb` are available for [bionic](https://dl.bintray.com/rabbitmq-erlang/debian/pool/erlang/21.3.8.2-1/ubuntu/bionic/), but not for [xenial](https://dl.bintray.com/rabbitmq-erlang/debian/pool/erlang/21.3.8.2-1/ubuntu/xenial/).

I don't know what these packages are used for in RabbitMQ, but from what I can gather, things appear to be working without them.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Please tell me if I'm doing something wrong. :)

Fixes this error:

```
  * rabbitmq_erlang_package_from_bintray[rabbitmq_erlang] action install
    * apt_package[erlang-base, erlang-mnesia, erlang-runtime-tools, erlang-asn1, erlang-crypto, erlang-public-key, erlang-ssl, erlang-syntax-tools, erlang-snmp, erlang-os-mon, erlang-parsetools, erlang-ftp, erlang-tftp, erlang-inets, erlang-tools, erlang-eldap, erlang-xmerl, erlang-dev, erlang-edoc, erlang-eunit, erlang-erl-docgen, erlang-src] action install
      * No candidate version available for erlang-ftp, erlang-tftp
      ================================================================================
      Error executing action `install` on resource 'apt_package[erlang-base, erlang-mnesia, erlang-runtime-tools, erlang-asn1, erlang-crypto, erlang-public-key, erlang-ssl, erlang-syntax-tools, erlang-snmp, erlang-os-mon, erlang-parsetools, erlang-ftp, erlang-tftp, erlang-inets, erlang-tools, erlang-eldap, erlang-xmerl, erlang-dev, erlang-edoc, erlang-eunit, erlang-erl-docgen, erlang-src]'
      ================================================================================

      Chef::Exceptions::Package
      -------------------------
      No candidate version available for erlang-ftp, erlang-tftp

      Resource Declaration:
      ---------------------
      # In /etc/chef/local-mode-cache/cache/cookbooks/rabbitmq/providers/erlang_package_from_bintray.rb

       52:     apt_package(erlang_packages) do
       53:       options new_resource.options unless new_resource.options.nil?
       54:       # must provide an array of versions!
       55:       version erlang_packages.map { new_resource.version } unless new_resource.version.nil?
       56:       retries new_resource.retries
       57:       retry_delay new_resource.retry_delay unless new_resource.retry_delay.nil?
       58:       action :install
       59:     end
       60:   end
```
