### PR TITLE
Support channel max attribute

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -116,6 +116,7 @@ default['rabbitmq']['logrotate']['postrotate'] = '/usr/sbin/rabbitmqctl rotate_l
 default['rabbitmq']['disk_free_limit_relative'] = nil
 default['rabbitmq']['disk_free_limit'] = nil
 default['rabbitmq']['vm_memory_high_watermark'] = nil
+default['rabbitmq']['channel_max'] = nil
 default['rabbitmq']['max_file_descriptors'] = 1024
 default['rabbitmq']['open_file_limit'] = nil
 

--- a/templates/default/rabbitmq.config.erb
+++ b/templates/default/rabbitmq.config.erb
@@ -114,6 +114,9 @@
 <% if node['rabbitmq']['vm_memory_high_watermark'] -%>
     {vm_memory_high_watermark, <%= node['rabbitmq']['vm_memory_high_watermark'] %>},
 <% end %>
+<% if node['rabbitmq']['channel_max'] -%>
+    {channel_max, <%= node['rabbitmq']['channel_max'] %>},
+<% end %>
 <% if node['rabbitmq']['loopback_users'] -%>
     {loopback_users, [<%= node['rabbitmq']['loopback_users'].map{|n| "<<\"#{n}\">>"}.join(',') %>]},
 <% end %>


### PR DESCRIPTION
## Proposed Changes

Added the ability to configure channel_max attribute

This changes were made to enable max channels per connection in my company.

## Types of Changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
