### PR TITLE
 Update openSUSE to leap 15

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -19,9 +19,9 @@ verifier:
   sudo: false
 
 platforms:
-  - name: opensuse-leap-42.3
+  - name: opensuse-leap-15
     driver:
-      image: dokken/opensuse-leap-42
+      image: dokken/opensuse-leap-15
       platform: suse
       pid_one_command: /usr/lib/systemd/systemd
       hostname: localhost
@@ -465,13 +465,11 @@ suites:
       - recipe[rabbitmq::default]
     attributes:
         rabbitmq:
-          version: "3.7.19"
           erlang:
             enabled: true
-            version: "21.3.2"
             zypper:
-              baseurl: https://download.opensuse.org/repositories/network:/messaging:/amqp/openSUSE_Leap_42.3/
+              baseurl: https://download.opensuse.org/repositories/network:/messaging:/amqp/openSUSE_Leap_15.1/
     verifier:
       inspec_tests:
         - test/erlang_package/latest_rpm
-    includes: ["opensuse-leap-42.3"]
+    includes: ["opensuse-leap-15"]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,7 +23,7 @@ platforms:
   - name: fedora-29
   - name: fedora-30
   - name: centos-6
-  - name: opensuse-leap-42.3
+  - name: opensuse-leap-15
 
 #
 # Suites
@@ -381,13 +381,11 @@ suites:
       - recipe[rabbitmq::default]
     attributes:
         rabbitmq:
-          version: "3.7.19"
           erlang:
             enabled: true
-            version: "21.3.2"
             zypper:
-              baseurl: https://download.opensuse.org/repositories/network:/messaging:/amqp/openSUSE_Leap_42.3/
+              baseurl: https://download.opensuse.org/repositories/network:/messaging:/amqp/openSUSE_Leap_15.1
     verifier:
       inspec_tests:
         - test/erlang_package/latest_rpm
-    includes: ["opensuse-leap-42.3"]
+    includes: ["opensuse-leap-15"]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -290,5 +290,5 @@ default['rabbitmq']['erlang']['yum']['enabled'] = true
 
 # zypper
 
-default['rabbitmq']['erlang']['zypper']['baseurl'] = 'https://download.opensuse.org/repositories/network:/messaging:/amqp/openSUSE_Leap_42.3/'
+default['rabbitmq']['erlang']['zypper']['baseurl'] = 'https://download.opensuse.org/repositories/network:/messaging:/amqp/openSUSE_Leap_15.1/'
 default['rabbitmq']['erlang']['zypper']['enabled'] = true


### PR DESCRIPTION
## Proposed Changes
Update the openSUSE form  `opensuse-leap-42.3` to  `leap 15.1`
`leap 42.3` was discontinued the  [Jul 1st 2019](https://en.opensuse.org/Lifetime) 


## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I have tested it using docker:

```
KITCHEN_LOCAL_YAML=.kitchen.dokken.yml  kitchen converge  rabbitmq-erlang-latest-suse-opensuse-leap-15
...

  * service[rabbitmq-server] action start (up to date)
  * ohai[reload_packages] action reload
    - re-run ohai and merge results into node attributes

Running handlers:
Running handlers complete
Chef Infra Client finished, 8/21 resources updated in 15 seconds
       Finished converging <rabbitmq-erlang-latest-suse-opensuse-leap-15> (0m17.62s).
-----> Test Kitchen is finished. (0m22.11s)
```