### PR TITLE
Add compress to logrotate options

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -110,7 +110,7 @@ default['rabbitmq']['logrotate']['enable'] = true
 default['rabbitmq']['logrotate']['path'] = '/var/log/rabbitmq/*.log'
 default['rabbitmq']['logrotate']['rotate'] = 20
 default['rabbitmq']['logrotate']['frequency'] = 'weekly'
-default['rabbitmq']['logrotate']['options'] = %w(missingok notifempty delaycompress)
+default['rabbitmq']['logrotate']['options'] = %w(missingok notifempty compress delaycompress)
 default['rabbitmq']['logrotate']['sharedscripts'] = true
 default['rabbitmq']['logrotate']['postrotate'] = '/usr/sbin/rabbitmqctl rotate_logs > /dev/null'
 


### PR DESCRIPTION
## Proposed Changes

Logrotate option `delaycompress` has no effect without `compress`. This PR simply adds the `compress` option to the list of default options.

From the [man page](https://linux.die.net/man/8/logrotate):
>Postpone compression of the previous log file to the next rotation cycle. **This only has effect when used in combination with compress.** It can be used when some program cannot be told to close its logfile and thus might continue writing to the previous log file for some time.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [X] I have read the `CONTRIBUTING.md` document
- [X] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

N/A