### PR TITLE
[#548] Specify output formatting when getting cluster_status on RabbitMQ 3.8

### DIFF
--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -43,15 +43,20 @@ end
 
 # Get cluster status result
 def cluster_status
+  # Default formatting changed to "table" in 3.8, need to explicity specify
+  # "erlang" to parse output properly.
+  installed_version = Gem::Version.new(installed_rabbitmq_version)
+  version_requiring_formatter = Gem::Version.new('3.8.0')
+  cmd = +'rabbitmqctl -q cluster_status'
+  cmd << ' --formatter erlang' if installed_version >= version_requiring_formatter
   # execute > rabbitmqctl cluster_status"
   # This removes an optional "... Done" linee that older version used to output
-  cmd = 'rabbitmqctl -q cluster_status'
   Chef::Log.debug("[rabbitmq_cluster] Executing #{cmd}")
   cmd = get_shellout(cmd)
   cmd.run_command
   cmd.error!
   result = cmd.stdout.squeeze(' ').gsub(/\n */, '').gsub('...done.', '')
-  Chef::Log.debug("[rabbitmq_cluster] rabbitmqctl cluster_status : #{result}")
+  Chef::Log.debug("[rabbitmq_cluster] #{cmd} : #{result}")
   result
 end
 


### PR DESCRIPTION
## Proposed Changes

Fixes #548

Default rabbitmqctl output formatting changed to "table" in RabbitMQ 3.8
Need to explicitly specify "erlang" formatting when getting
cluster_status in order to properly parse output.

Fixes non-idempotency of `rabbitmq::cluster` recipe on RabbitMQ 3.8.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #548 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
