### PR TITLE
Switch foodcritic + rubocop for cookstyle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,13 +1,13 @@
 AsciiComments:
   Enabled: false
 
-ChefStyle/CommentFormat:
+Chef/Style/CommentFormat:
   Enabled: false
 
-ChefModernize/FoodcriticComments:
+Chef/Modernize/FoodcriticComments:
   Enabled: false
 
-ChefModernize/ExecuteSleep:
+Chef/Modernize/ExecuteSleep:
   Enabled: false
 
 Layout/ParameterAlignment:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'github_changelog_generator'
 gem 'stove'
 
 group :lint do
-  gem 'foodcritic', '>= 16.3'
   gem 'cookstyle'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -916,7 +916,6 @@ DEPENDENCIES
   chef
   chefspec
   cookstyle
-  foodcritic (>= 16.3)
   github_changelog_generator
   growl
   guard

--- a/Guardfile
+++ b/Guardfile
@@ -13,14 +13,6 @@
 
 # rubocop:disable all
 
-guard 'foodcritic', :cookbook_paths => '.', :all_on_start => false do
-  watch(%r{attributes/.+\.rb$})
-  watch(%r{providers/.+\.rb$})
-  watch(%r{recipes/.+\.rb$})
-  watch(%r{resources/.+\.rb$})
-  watch('metadata.rb')
-end
-
 guard 'rubocop', :all_on_start => false do
   watch(%r{attributes/.+\.rb$})
   watch(%r{providers/.+\.rb$})

--- a/Rakefile
+++ b/Rakefile
@@ -12,25 +12,10 @@ namespace :style do
   rescue LoadError => e
     puts ">>> Gem load error: #{e}, omitting style:ruby" unless ENV['CI']
   end
-
-  begin
-    require 'foodcritic'
-
-    desc 'Run Chef style checks'
-    FoodCritic::Rake::LintTask.new(:chef) do |t|
-      t.options = {
-        :fail_tags => ['any'],
-        :tags => %w(~FC007 ~FC023 ~FC085),
-        :progress => true,
-      }
-    end
-  rescue LoadError
-    puts ">>> Gem load error: #{e}, omitting style:chef" unless ENV['CI']
-  end
 end
 
 desc 'Run all style checks'
-task :style => ['style:chef', 'style:ruby']
+task :style => ['style:ruby']
 
 # ChefSpec
 begin

--- a/TESTING.md
+++ b/TESTING.md
@@ -23,29 +23,19 @@ rake integration:cloud    # Run Test Kitchen with cloud plugins
 rake integration:vagrant  # Run Test Kitchen with Vagrant
 rake spec                 # Run ChefSpec examples
 rake style                # Run all style checks
-rake style:chef           # Lint Chef cookbooks
 rake style:ruby           # Run Ruby style checks
 rake travis               # Run all tests on Travis
 ```
 
 ## Style Testing
 
-Ruby style tests can be performed by Rubocop by issuing either
+Ruby style tests can be performed by Cookstyle by issuing either
 ```
-bundle exec rubocop
+bundle exec cookstyle
 ```
 or
 ```
 rake style:ruby
-```
-
-Chef style tests can be performed with Foodcritic by issuing either
-```
-bundle exec foodcritic
-```
-or
-```
-rake style:chef
 ```
 
 ## Spec Testing
@@ -78,13 +68,13 @@ is [only compatible with Docker Desktop `4.2.x`](https://github.com/test-kitchen
 To list available configurations that can be run, use
 
 ```
-KICHEN_LOCAL_YAML=".kitchen.dokken.yml" kitchen list
+KITCHEN_LOCAL_YAML=".kitchen.dokken.yml" kitchen list
 ```
 
 To run Kitchen tests in Docker, use
 
 ```
-KICHEN_LOCAL_YAML=".kitchen.dokken.yml" kitchen test default-deb --concurrency=2
+KITCHEN_LOCAL_YAML=".kitchen.dokken.yml" kitchen test default-deb --concurrency=2
 ```
 
 where `default-deb` is a prefix of a group of configurations (they can be run in parallel

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -265,7 +265,7 @@ default['rabbitmq']['erlang']['apt']['uri'] = "https://dl.cloudsmith.io/public/r
 unless node['lsb'].nil?
   default['rabbitmq']['erlang']['apt']['lsb_codename'] = node['lsb']['codename']
 end
-default['rabbitmq']['erlang']['apt']['components'] = ["main"]
+default['rabbitmq']['erlang']['apt']['components'] = ['main']
 default['rabbitmq']['erlang']['apt']['key'] = 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key'
 
 default['rabbitmq']['erlang']['apt']['install_options'] = %w(--fix-missing)
@@ -281,7 +281,7 @@ default['rabbitmq']['erlang']['yum']['baseurl'] = value_for_platform(
   },
   'amazon' => {
     # Amazon Linux 2022 uses el/8 as it is based on Fedora 34+
-    '>= 2022'  => 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el/8/$basearch',
+    '>= 2022' => 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el/8/$basearch',
     # Amazon Linux 2 uses el/7 as it is based on CentOS 7
     '< 2022'  => 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el/7/$basearch',
     'default' => 'https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/rpm/el/8/$basearch'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -33,7 +33,7 @@ module RabbitMQ
       # Otherwise, we can just render it nicely as Erlang wants. This
       # theoretically opens the door for arbitrary kernel_app parameters to be
       # declared.
-      kernel.select { |_k, v| !v.nil? }.each_pair do |param, val|
+      kernel.compact.each_pair do |param, val|
         rendered << "    {#{param}, #{val}}"
       end
 
@@ -114,7 +114,7 @@ module RabbitMQ
     end
 
     def service_control_systemd?
-      node['init_package'] == 'systemd' || node['rabbitmq']['job_control'] == 'systemd'
+      systemd? || node['rabbitmq']['job_control'] == 'systemd'
     end
   end
 end

--- a/providers/cluster.rb
+++ b/providers/cluster.rb
@@ -23,8 +23,7 @@ include RabbitMQ::CoreHelpers
 
 # Get ShellOut
 def get_shellout(cmd)
-  sh_cmd = Mixlib::ShellOut.new(cmd, :env => shell_environment)
-  sh_cmd
+  Mixlib::ShellOut.new(cmd, :env => shell_environment)
 end
 
 # Execute rabbitmqctl command with args

--- a/providers/erlang_zypper_repository_on_suse_factory.rb
+++ b/providers/erlang_zypper_repository_on_suse_factory.rb
@@ -50,8 +50,6 @@ action :create do
     sslclientkey new_resource.sslclientkey unless new_resource.sslclientkey.nil?
     sslverify new_resource.sslverify unless new_resource.sslverify.nil?
 
-    timeout new_resource.timeout unless new_resource.timeout.nil?
-
     notifies :run, 'execute[zypper refresh]', :immediately
 
     action :create

--- a/resources/erlang_yum_repository_on_cloudsmith.rb
+++ b/resources/erlang_yum_repository_on_cloudsmith.rb
@@ -41,5 +41,3 @@ attribute :sslcacert, String
 attribute :sslclientcert, String
 attribute :sslclientkey, String
 attribute :sslverify, [true, false]
-
-attribute :timeout

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -9,7 +9,7 @@ describe 'rabbitmq_policy' do
     before do
       shellout = double
       allow(Mixlib::ShellOut).to receive(:new).with(
-        /rabbitmqctl list_policies/, {env: { 'HOME' => // } }
+        /rabbitmqctl list_policies/, { env: { 'HOME' => // } }
       ).and_return(shellout)
       allow(shellout).to receive(:run_command).and_return(shellout)
       allow(shellout).to receive(:stdout).and_return('[]')
@@ -44,7 +44,7 @@ describe 'rabbitmq_policy' do
     before do
       shellout = double
       allow(Mixlib::ShellOut).to receive(:new).with(
-        /rabbitmqctl list_policies/, {env: { 'HOME' => // } }
+        /rabbitmqctl list_policies/, { env: { 'HOME' => // } }
       ).and_return(shellout)
       allow(shellout).to receive(:run_command).and_return(shellout)
       allow(shellout).to receive(:stdout).and_return(


### PR DESCRIPTION
Foodcritic is deprecated, long live cookstyle.

Ran cookstyle and corrected everything it found.

Drive-by fixed some typos in TESTING.md.
